### PR TITLE
add support for CipherContext.update_nonce

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,9 @@ Changelog
   and :class:`~cryptography.hazmat.primitives.ciphers.algorithms.ARC4` into
   :doc:`/hazmat/decrepit/index` and deprecated them in the ``cipher`` module.
   They will be removed from the ``cipher`` module in 48.0.0.
+* Added :meth:`~cryptography.hazmat.primitives.ciphers.CipherContext.update_nonce`
+  for altering the ``nonce`` of a cipher context without initializing a new
+  instance. See the docs for additional restrictions.
 
 .. _v42-0-3:
 

--- a/docs/hazmat/primitives/symmetric-encryption.rst
+++ b/docs/hazmat/primitives/symmetric-encryption.rst
@@ -693,6 +693,27 @@ Interfaces
         :meth:`update` and :meth:`finalize` will raise an
         :class:`~cryptography.exceptions.AlreadyFinalized` exception.
 
+    .. method:: update_nonce(nonce)
+
+        .. versionadded:: 43.0.0
+
+        This method allows updating the nonce for an already existing context.
+        Normally the nonce is set when the context is created and internally
+        incremented as data as passed. However, in some scenarios the same key
+        is used repeatedly but the nonce changes non-sequentially (e.g. ``QUIC``),
+        which requires updating the context with the new nonce.
+
+        This method only works for contexts using
+        :class:`~cryptography.hazmat.primitives.ciphers.algorithms.ChaCha20` or
+        :class:`~cryptography.hazmat.primitives.ciphers.modes.CTR` mode.
+
+        :param nonce: The nonce to update the context with.
+        :type data: :term:`bytes-like`
+        :raises cryptography.exceptions.UnsupportedAlgorithm: If the
+            algorithm does not support updating the nonce.
+        :raises ValueError: If the nonce is not the correct length for the
+            algorithm.
+
 .. class:: AEADCipherContext
 
     When calling ``encryptor`` or ``decryptor`` on a ``Cipher`` object

--- a/src/cryptography/hazmat/primitives/ciphers/base.py
+++ b/src/cryptography/hazmat/primitives/ciphers/base.py
@@ -33,6 +33,14 @@ class CipherContext(metaclass=abc.ABCMeta):
         Returns the results of processing the final block as bytes.
         """
 
+    @abc.abstractmethod
+    def update_nonce(self, nonce: bytes) -> None:
+        """
+        Updates the nonce for the cipher context to the provided value.
+        Raises an exception if it does not support reset or if the
+        provided nonce does not have a valid length.
+        """
+
 
 class AEADCipherContext(CipherContext, metaclass=abc.ABCMeta):
     @abc.abstractmethod

--- a/tests/hazmat/primitives/test_aes.py
+++ b/tests/hazmat/primitives/test_aes.py
@@ -8,11 +8,12 @@ import os
 
 import pytest
 
+from cryptography.exceptions import AlreadyFinalized, _Reasons
 from cryptography.hazmat.bindings._rust import openssl as rust_openssl
 from cryptography.hazmat.primitives.ciphers import algorithms, base, modes
 
 from ...doubles import DummyMode
-from ...utils import load_nist_vectors
+from ...utils import load_nist_vectors, raises_unsupported_algorithm
 from .utils import _load_all_params, generate_encrypt_test
 
 
@@ -305,3 +306,43 @@ def test_alternate_aes_classes(mode, alg_cls, backend):
     dec = cipher.decryptor()
     pt = dec.update(ct) + dec.finalize()
     assert pt == data
+
+
+def test_update_nonce(backend):
+    data = b"helloworld" * 10
+    nonce = b"\x00" * 16
+    c = base.Cipher(
+        algorithms.AES(b"\x00" * 16),
+        modes.CTR(nonce),
+    )
+    enc = c.encryptor()
+    ct1 = enc.update(data)
+    assert len(ct1) == len(data)
+    for _ in range(2):
+        enc.update_nonce(nonce)
+        assert enc.update(data) == ct1
+    enc.finalize()
+    with pytest.raises(AlreadyFinalized):
+        enc.update_nonce(nonce)
+    dec = c.decryptor()
+    assert dec.update(ct1) == data
+    for _ in range(2):
+        dec.update_nonce(nonce)
+        assert dec.update(ct1) == data
+    dec.finalize()
+    with pytest.raises(AlreadyFinalized):
+        dec.update_nonce(nonce)
+
+
+def test_update_nonce_invalid_mode(backend):
+    iv = b"\x00" * 16
+    c = base.Cipher(
+        algorithms.AES(b"\x00" * 16),
+        modes.CBC(iv),
+    )
+    enc = c.encryptor()
+    with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_CIPHER):
+        enc.update_nonce(iv)
+    dec = c.decryptor()
+    with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_CIPHER):
+        dec.update_nonce(iv)

--- a/tests/hazmat/primitives/test_aes_gcm.py
+++ b/tests/hazmat/primitives/test_aes_gcm.py
@@ -8,10 +8,11 @@ import os
 
 import pytest
 
+from cryptography.exceptions import _Reasons
 from cryptography.hazmat.bindings._rust import openssl as rust_openssl
 from cryptography.hazmat.primitives.ciphers import algorithms, base, modes
 
-from ...utils import load_nist_vectors
+from ...utils import load_nist_vectors, raises_unsupported_algorithm
 from .utils import generate_aead_test
 
 
@@ -230,3 +231,16 @@ class TestAESModeGCM:
         dec = cipher.decryptor()
         pt = dec.update(ct) + dec.finalize_with_tag(enc.tag)
         assert pt == data
+
+    def test_update_nonce_invalid_mode(self, backend):
+        nonce = b"\x00" * 12
+        c = base.Cipher(
+            algorithms.AES(b"\x00" * 16),
+            modes.GCM(nonce),
+        )
+        enc = c.encryptor()
+        with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_CIPHER):
+            enc.update_nonce(nonce)
+        dec = c.decryptor()
+        with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_CIPHER):
+            dec.update_nonce(nonce)

--- a/tests/hazmat/primitives/test_chacha20.py
+++ b/tests/hazmat/primitives/test_chacha20.py
@@ -9,6 +9,7 @@ import struct
 
 import pytest
 
+from cryptography.exceptions import AlreadyFinalized
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
 
 from ...utils import load_nist_vectors
@@ -90,3 +91,36 @@ class TestChaCha20:
         ct_partial_3 = enc_partial.update(pt[len_partial * 2 :])
 
         assert ct_full == ct_partial_1 + ct_partial_2 + ct_partial_3
+
+    def test_update_nonce(self, backend):
+        data = b"helloworld" * 10
+        key = b"\x00" * 32
+        nonce = b"\x00" * 16
+        cipher = Cipher(algorithms.ChaCha20(key, nonce), None)
+        enc = cipher.encryptor()
+        ct1 = enc.update(data)
+        assert len(ct1) == len(data)
+        for _ in range(2):
+            enc.update_nonce(nonce)
+            assert enc.update(data) == ct1
+        enc.finalize()
+        with pytest.raises(AlreadyFinalized):
+            enc.update_nonce(nonce)
+        dec = cipher.decryptor()
+        assert dec.update(ct1) == data
+        for _ in range(2):
+            dec.update_nonce(nonce)
+            assert dec.update(ct1) == data
+        dec.finalize()
+        with pytest.raises(AlreadyFinalized):
+            dec.update_nonce(nonce)
+
+    def test_nonce_reset_invalid_length(self, backend):
+        key = b"\x00" * 32
+        nonce = b"\x00" * 16
+        cipher = Cipher(algorithms.ChaCha20(key, nonce), None)
+        enc = cipher.encryptor()
+        with pytest.raises(ValueError):
+            enc.update_nonce(nonce[:-1])
+        with pytest.raises(ValueError):
+            enc.update_nonce(nonce + b"\x00")


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#10437](https://togithub.com/pyca/cryptography/pull/10437).



The original branch is fork-10437-reaperhulk/nonce-reset