### PR TITLE
Bump BoringSSL and/or OpenSSL in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
           - {VERSION: "3.12", NOXSESSION: "rust,tests", OPENSSL: {TYPE: "libressl", VERSION: "3.8.4"}}
           - {VERSION: "3.12", NOXSESSION: "rust,tests", OPENSSL: {TYPE: "libressl", VERSION: "3.9.1"}}
           - {VERSION: "3.12", NOXSESSION: "tests-randomorder"}
-          # Latest commit on the BoringSSL master branch, as of Apr 27, 2024.
-          - {VERSION: "3.12", NOXSESSION: "rust,tests", OPENSSL: {TYPE: "boringssl", VERSION: "d69e8b46184b6fd844a4a92b4a6f4347d08ee439"}}
-          # Latest commit on the OpenSSL master branch, as of Apr 27, 2024.
-          - {VERSION: "3.12", NOXSESSION: "tests", OPENSSL: {TYPE: "openssl", VERSION: "933f57dfe21657f7aba8f13e0cdb3b02dd64fcc3"}}
+          # Latest commit on the BoringSSL master branch, as of Apr 30, 2024.
+          - {VERSION: "3.12", NOXSESSION: "rust,tests", OPENSSL: {TYPE: "boringssl", VERSION: "2db0eb3f96a5756298dcd7f9319e56a98585bd10"}}
+          # Latest commit on the OpenSSL master branch, as of Apr 30, 2024.
+          - {VERSION: "3.12", NOXSESSION: "tests", OPENSSL: {TYPE: "openssl", VERSION: "6a4a714045415be6720f4165c4d70a0ff229a26a"}}
           # Builds with various Rust versions. Includes MSRV and next
           # potential future MSRV.
           - {VERSION: "3.12", NOXSESSION: "rust,tests", RUST: "1.65.0"}


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#10846](https://togithub.com/pyca/cryptography/pull/10846).



The original branch is upstream/bump-openssl-boringssl