### PR TITLE
Bump sphinx from 7.3.5 to 7.3.6

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -109,7 +109,7 @@ ruff==0.3.7
     # via cryptography (pyproject.toml)
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==7.3.5
+sphinx==7.3.6
     # via
     #   cryptography (pyproject.toml)
     #   sphinx-rtd-theme


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#10847](https://togithub.com/pyca/cryptography/pull/10847).



The original branch is upstream/dependabot/pip/sphinx-7.3.6