### PR TITLE
Add timezone-aware API variant for `x509.InvalidityDate.invalidity_date`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,9 @@ Changelog
   :attr:`~cryptography.x509.CertificateSigningRequest.public_key_algorithm_oid`
   to determine the :class:`~cryptography.hazmat._oid.PublicKeyAlgorithmOID`
   Object Identifier of the public key found inside the certificate.
+* Added :attr:`~cryptography.x509.InvalidityDate.invalidity_date_utc`, a
+  timezone-aware alternative to the naïve ``datetime`` attribute
+  :attr:`~cryptography.x509.InvalidityDate.invalidity_date`.
 
 .. _v42-0-5:
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -3148,6 +3148,14 @@ These extensions are only valid within a :class:`RevokedCertificate` object.
 
         :type: :class:`datetime.datetime`
 
+    .. attribute:: invalidity_date_utc
+
+        .. versionadded:: 43.0.0
+
+        :type: :class:`datetime.datetime`
+
+        The invalidity date in UTC as a timezone-aware datetime object.
+
 OCSP Extensions
 ~~~~~~~~~~~~~~~
 

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -1788,6 +1788,13 @@ class InvalidityDate(ExtensionType):
     def invalidity_date(self) -> datetime.datetime:
         return self._invalidity_date
 
+    @property
+    def invalidity_date_utc(self) -> datetime.datetime:
+        if self._invalidity_date.tzinfo is None:
+            return self._invalidity_date.replace(tzinfo=datetime.timezone.utc)
+        else:
+            return self._invalidity_date.astimezone(tz=datetime.timezone.utc)
+
     def public_bytes(self) -> bytes:
         return rust_x509.encode_extension_value(self)
 

--- a/src/rust/src/x509/extensions.rs
+++ b/src/rust/src/x509/extensions.rs
@@ -530,7 +530,7 @@ pub(crate) fn encode_extension(
             Ok(Some(asn1::write_single(&asn1::SequenceOfWriter::new(gns))?))
         }
         &oid::INVALIDITY_DATE_OID => {
-            let py_dt = ext.getattr(pyo3::intern!(py, "invalidity_date"))?;
+            let py_dt = ext.getattr(pyo3::intern!(py, "invalidity_date_utc"))?;
             let dt = x509::py_to_datetime(py, py_dt)?;
             Ok(Some(asn1::write_single(&asn1::GeneralizedTime::new(dt)?)?))
         }

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -444,6 +444,26 @@ class TestInvalidityDate:
         ext = x509.InvalidityDate(datetime.datetime(2015, 1, 1, 1, 1))
         assert ext.public_bytes() == b"\x18\x0f20150101010100Z"
 
+    def test_timezone_aware_api(self):
+        naive_date = datetime.datetime(2015, 1, 1, 1, 1)
+        ext_naive = x509.InvalidityDate(invalidity_date=naive_date)
+        assert ext_naive.invalidity_date_utc == datetime.datetime(
+            2015, 1, 1, 1, 1, tzinfo=datetime.timezone.utc
+        )
+
+        tz_aware_date = datetime.datetime(
+            2015,
+            1,
+            1,
+            1,
+            1,
+            tzinfo=datetime.timezone(datetime.timedelta(hours=-8)),
+        )
+        ext_aware = x509.InvalidityDate(invalidity_date=tz_aware_date)
+        assert ext_aware.invalidity_date_utc == datetime.datetime(
+            2015, 1, 1, 9, 1, tzinfo=datetime.timezone.utc
+        )
+
 
 class TestNoticeReference:
     def test_notice_numbers_not_all_int(self):


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#10848](https://togithub.com/pyca/cryptography/pull/10848).



The original branch is fork-10848-trail-of-forks/invalidity-date-utc