### PR TITLE
Bump exceptiongroup from 1.2.0 to 1.2.1

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -36,7 +36,7 @@ docutils==0.20.1
     #   readme-renderer
     #   sphinx
     #   sphinx-rtd-theme
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via pytest
 execnet==2.1.1; python_version >= "3.8"
     # via pytest-xdist


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#10852](https://togithub.com/pyca/cryptography/pull/10852).



The original branch is upstream/dependabot/pip/exceptiongroup-1.2.1