### PR TITLE
Bump actions/upload-artifact from 4.3.1 to 4.3.2 in /.github/actions/upload-coverage

### DIFF
--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -13,7 +13,7 @@ runs:
         fi
       id: coverage-uuid
       shell: bash
-    - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+    - uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4.3.2
       with:
         name: coverage-data-${{ steps.coverage-uuid.outputs.COVERAGE_UUID }}
         path: |


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#10854](https://togithub.com/pyca/cryptography/pull/10854).



The original branch is upstream/dependabot/github_actions/dot-github/actions/upload-coverage/actions/upload-artifact-4.3.2