### PR TITLE
Bump cc from 1.0.94 to 1.0.95 in /src/rust

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -48,9 +48,9 @@ checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "cc"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 
 [[package]]
 name = "cfg-if"

--- a/src/rust/cryptography-cffi/Cargo.toml
+++ b/src/rust/cryptography-cffi/Cargo.toml
@@ -12,4 +12,4 @@ pyo3 = { version = "0.21.2", features = ["abi3"] }
 openssl-sys = "0.9.102"
 
 [build-dependencies]
-cc = "1.0.94"
+cc = "1.0.95"


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#10861](https://togithub.com/pyca/cryptography/pull/10861).



The original branch is upstream/dependabot/cargo/src/rust/cc-1.0.95