### PR TITLE
Bump pluggy from 1.4.0 to 1.5.0

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -70,7 +70,7 @@ pathspec==0.12.1
     # via check-sdist
 platformdirs==4.2.0; python_version >= "3.8"
     # via virtualenv
-pluggy==1.4.0; python_version >= "3.8"
+pluggy==1.5.0; python_version >= "3.8"
     # via pytest
 pretend==1.0.9
     # via cryptography (pyproject.toml)


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#10866](https://togithub.com/pyca/cryptography/pull/10866).



The original branch is upstream/dependabot/pip/pluggy-1.5.0