### PR TITLE
Bump platformdirs from 4.2.0 to 4.2.1

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -68,7 +68,7 @@ packaging==24.0
     #   sphinx
 pathspec==0.12.1
     # via check-sdist
-platformdirs==4.2.0; python_version >= "3.8"
+platformdirs==4.2.1; python_version >= "3.8"
     # via virtualenv
 pluggy==1.5.0; python_version >= "3.8"
     # via pytest


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#10875](https://togithub.com/pyca/cryptography/pull/10875).



The original branch is upstream/dependabot/pip/platformdirs-4.2.1