### PR TITLE
Add support for encrypting S/MIME messages

### DIFF
--- a/src/cryptography/hazmat/bindings/_rust/pkcs7.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/pkcs7.pyi
@@ -12,6 +12,11 @@ def serialize_certificates(
     certs: list[x509.Certificate],
     encoding: serialization.Encoding,
 ) -> bytes: ...
+def encrypt_and_serialize(
+    builder: pkcs7.PKCS7EnvelopeBuilder,
+    encoding: serialization.Encoding,
+    options: typing.Iterable[pkcs7.PKCS7Options],
+) -> bytes: ...
 def sign_and_serialize(
     builder: pkcs7.PKCS7SignatureBuilder,
     encoding: serialization.Encoding,

--- a/src/cryptography/hazmat/primitives/serialization/pkcs7.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs7.py
@@ -12,6 +12,7 @@ import io
 import typing
 
 from cryptography import utils, x509
+from cryptography.exceptions import UnsupportedAlgorithm, _Reasons
 from cryptography.hazmat.bindings._rust import pkcs7 as rust_pkcs7
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
@@ -183,6 +184,16 @@ class PKCS7EnvelopeBuilder:
         data: bytes | None = None,
         recipients: list[x509.Certificate] | None = None,
     ):
+        from cryptography.hazmat.backends.openssl.backend import (
+            backend as ossl,
+        )
+
+        if not ossl.rsa_encryption_supported(padding=padding.PKCS1v15()):
+            raise UnsupportedAlgorithm(
+                "RSA with PKCS1 v1.5 padding is not supported by this version"
+                " of OpenSSL.",
+                _Reasons.UNSUPPORTED_PADDING,
+            )
         self._data = data
         self._recipients = recipients if recipients is not None else []
 

--- a/src/cryptography/hazmat/primitives/serialization/pkcs7.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs7.py
@@ -313,15 +313,7 @@ def _smime_enveloped_encode(data: bytes) -> bytes:
 
     m.set_payload(email.base64mime.body_encode(data, maxlinelen=65))
 
-    fp = io.BytesIO()
-    g = email.generator.BytesGenerator(
-        fp,
-        maxheaderlen=0,
-        mangle_from_=False,
-        policy=m.policy.clone(linesep="\n"),
-    )
-    g.flatten(m)
-    return fp.getvalue()
+    return m.as_bytes(policy=m.policy.clone(linesep="\n", max_line_length=0))
 
 
 class OpenSSLMimePart(email.message.MIMEPart):

--- a/src/cryptography/hazmat/primitives/serialization/pkcs7.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs7.py
@@ -308,9 +308,6 @@ def _smime_signed_encode(
 
 
 def _smime_enveloped_encode(data: bytes) -> bytes:
-    # This function works pretty hard to replicate what OpenSSL does
-    # precisely. For good and for ill.
-
     m = email.message.Message()
     m.add_header("MIME-Version", "1.0")
     m.add_header("Content-Disposition", "attachment", filename="smime.p7m")

--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -57,6 +57,17 @@ pub enum AlgorithmParameters<'a> {
     #[defined_by(oid::RSA_OID)]
     Rsa(Option<asn1::Null>),
 
+    // Used only in PKCS#7 AlgorithmIdentifiers
+    // https://datatracker.ietf.org/doc/html/rfc3565#section-4.1
+    //
+    // From RFC 3565 section 4.1:
+    // The AlgorithmIdentifier parameters field MUST be present, and the
+    // parameters field MUST contain a AES-IV:
+    //
+    // AES-IV ::= OCTET STRING (SIZE(16))
+    #[defined_by(oid::AES_128_CBC_OID)]
+    AesCbc(&'a [u8]),
+
     // These ECDSA algorithms should have no parameters,
     // but Java 11 (up to at least 11.0.19) encodes them
     // with NULL parameters. The JDK team is looking to

--- a/src/rust/cryptography-x509/src/oid.rs
+++ b/src/rust/cryptography-x509/src/oid.rs
@@ -74,6 +74,9 @@ pub const EC_BRAINPOOLP384R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 36, 3, 3
 pub const EC_BRAINPOOLP512R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 36, 3, 3, 2, 8, 1, 1, 13);
 
 pub const RSA_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 1, 1);
+pub const AES_256_CBC_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101, 3, 4, 1, 42);
+pub const AES_192_CBC_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101, 3, 4, 1, 22);
+pub const AES_128_CBC_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101, 3, 4, 1, 2);
 
 // Signing methods
 pub const ECDSA_WITH_SHA224_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 10045, 4, 3, 1);

--- a/src/rust/src/pkcs7.rs
+++ b/src/rust/src/pkcs7.rs
@@ -6,7 +6,9 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ops::Deref;
 
+use cryptography_x509::common::{AlgorithmIdentifier, AlgorithmParameters};
 use cryptography_x509::csr::Attribute;
+use cryptography_x509::pkcs7::PKCS7_DATA_OID;
 use cryptography_x509::{common, oid, pkcs7};
 use once_cell::sync::Lazy;
 #[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
@@ -26,10 +28,6 @@ const PKCS7_CONTENT_TYPE_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113
 const PKCS7_MESSAGE_DIGEST_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 9, 4);
 const PKCS7_SIGNING_TIME_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 9, 5);
 const PKCS7_SMIME_CAP_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 9, 15);
-
-const AES_256_CBC_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101, 3, 4, 1, 42);
-const AES_192_CBC_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101, 3, 4, 1, 22);
-const AES_128_CBC_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101, 3, 4, 1, 2);
 
 static OIDS_TO_MIC_NAME: Lazy<HashMap<&asn1::ObjectIdentifier, &str>> = Lazy::new(|| {
     let mut h = HashMap::new();
@@ -80,6 +78,107 @@ fn serialize_certificates<'p>(
 }
 
 #[pyo3::prelude::pyfunction]
+fn encrypt_and_serialize<'p>(
+    py: pyo3::Python<'p>,
+    builder: &pyo3::Bound<'p, pyo3::PyAny>,
+    encoding: &pyo3::Bound<'p, pyo3::PyAny>,
+    options: &pyo3::Bound<'p, pyo3::types::PyList>,
+) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
+    let raw_data: CffiBuf<'p> = builder.getattr(pyo3::intern!(py, "_data"))?.extract()?;
+    let text_mode = options.contains(types::PKCS7_TEXT.get(py)?)?;
+    let data_with_header = if options.contains(types::PKCS7_BINARY.get(py)?)? {
+        Cow::Borrowed(raw_data.as_bytes())
+    } else {
+        smime_canonicalize(raw_data.as_bytes(), text_mode).0
+    };
+
+    let padder = types::SYMMETRIC_PADDING_PKCS7
+        .get(py)?
+        .call1((128,))?
+        .call_method0(pyo3::intern!(py, "padder"))?;
+    let padded_content_start =
+        padder.call_method1(pyo3::intern!(py, "update"), (data_with_header,))?;
+    let padded_content_end = padder.call_method0(pyo3::intern!(py, "finalize"))?;
+    let padded_content = padded_content_start.add(padded_content_end)?;
+
+    // The message is encrypted with AES-128-CBC, which the S/MIME v3.2 RFC
+    // specifies as MUST support (https://datatracker.ietf.org/doc/html/rfc5751#section-2.7)
+    let key = types::OS_URANDOM.get(py)?.call1((16,))?;
+    let aes128_algorithm = types::AES128.get(py)?.call1((&key,))?;
+    let iv = types::OS_URANDOM.get(py)?.call1((16,))?;
+    let cbc_mode = types::CBC.get(py)?.call1((&iv,))?;
+    let cipher = types::CIPHER.get(py)?.call1((aes128_algorithm, cbc_mode))?;
+    let encryptor = cipher.call_method0(pyo3::intern!(py, "encryptor"))?;
+    let encrypted_content_start =
+        encryptor.call_method1(pyo3::intern!(py, "update"), (padded_content,))?;
+    let encrypted_content_end = encryptor.call_method0(pyo3::intern!(py, "finalize"))?;
+    let encrypted_content = encrypted_content_start.add(encrypted_content_end)?;
+
+    let py_recipients: Vec<pyo3::Bound<'p, x509::certificate::Certificate>> = builder
+        .getattr(pyo3::intern!(py, "_recipients"))?
+        .extract()?;
+
+    let mut recipient_infos = vec![];
+    let ka_bytes = cryptography_keepalive::KeepAlive::new();
+    for cert in py_recipients.iter() {
+        // Currently, keys are encrypted with RSA (PKCS #1 v1.5), which the S/MIME v3.2 RFC
+        // specifies as MUST support (https://datatracker.ietf.org/doc/html/rfc5751#section-2.3)
+        let encrypted_key = cert
+            .call_method0(pyo3::intern!(py, "public_key"))?
+            .call_method1(
+                pyo3::intern!(py, "encrypt"),
+                (&key, types::PKCS1V15.get(py)?.call0()?),
+            )?
+            .extract::<pyo3::pybacked::PyBackedBytes>()?;
+
+        recipient_infos.push(pkcs7::RecipientInfo {
+            version: 0,
+            issuer_and_serial_number: pkcs7::IssuerAndSerialNumber {
+                issuer: cert.get().raw.borrow_dependent().tbs_cert.issuer.clone(),
+                serial_number: cert.get().raw.borrow_dependent().tbs_cert.serial,
+            },
+            key_encryption_algorithm: AlgorithmIdentifier {
+                oid: asn1::DefinedByMarker::marker(),
+                params: AlgorithmParameters::Rsa(Some(())),
+            },
+            encrypted_key: ka_bytes.add(encrypted_key),
+        });
+    }
+
+    let enveloped_data = pkcs7::EnvelopedData {
+        version: 0,
+        recipient_infos: asn1::SetOfWriter::new(&recipient_infos),
+
+        encrypted_content_info: pkcs7::EncryptedContentInfo {
+            _content_type: PKCS7_DATA_OID,
+            content_encryption_algorithm: AlgorithmIdentifier {
+                oid: asn1::DefinedByMarker::marker(),
+                params: AlgorithmParameters::AesCbc(iv.extract()?),
+            },
+            content: Some(encrypted_content.extract()?),
+        },
+    };
+
+    let content_info = pkcs7::ContentInfo {
+        _content_type: asn1::DefinedByMarker::marker(),
+        content: pkcs7::Content::EnvelopedData(asn1::Explicit::new(Box::new(enveloped_data))),
+    };
+    let ci_bytes = asn1::write_single(&content_info)?;
+
+    if encoding.is(&types::ENCODING_SMIME.get(py)?) {
+        Ok(types::SMIME_ENVELOPED_ENCODE
+            .get(py)?
+            .call1((&*ci_bytes,))?
+            .extract()?)
+    } else {
+        // Handles the DER, PEM, and error cases
+        // This uses the "CMS" tag for PEM encoding, matching the behavior of
+        // `openssl-cms` rather than the legacy `openssl-smime`.
+        encode_der_data(py, "CMS".to_string(), ci_bytes, encoding)
+    }
+}
+
+#[pyo3::prelude::pyfunction]
 fn sign_and_serialize<'p>(
     py: pyo3::Python<'p>,
     builder: &pyo3::Bound<'p, pyo3::PyAny>,
@@ -105,9 +204,9 @@ fn sign_and_serialize<'p>(
         // Subset of values OpenSSL provides:
         // https://github.com/openssl/openssl/blob/667a8501f0b6e5705fd611d5bb3ca24848b07154/crypto/pkcs7/pk7_smime.c#L150
         // removing all the ones that are bad cryptography
-        &asn1::SequenceOfWriter::new([AES_256_CBC_OID]),
-        &asn1::SequenceOfWriter::new([AES_192_CBC_OID]),
-        &asn1::SequenceOfWriter::new([AES_128_CBC_OID]),
+        &asn1::SequenceOfWriter::new([oid::AES_256_CBC_OID]),
+        &asn1::SequenceOfWriter::new([oid::AES_192_CBC_OID]),
+        &asn1::SequenceOfWriter::new([oid::AES_128_CBC_OID]),
     ]))?;
 
     #[allow(clippy::type_complexity)]
@@ -260,7 +359,7 @@ fn sign_and_serialize<'p>(
             .map(|d| OIDS_TO_MIC_NAME[&d.oid()])
             .collect::<Vec<_>>()
             .join(",");
-        Ok(types::SMIME_ENCODE
+        Ok(types::SMIME_SIGNED_ENCODE
             .get(py)?
             .call1((&*data_without_header, &*ci_bytes, mic_algs, text_mode))?
             .extract()?)
@@ -418,6 +517,10 @@ pub(crate) fn create_submodule(
 
     submod.add_function(pyo3::wrap_pyfunction_bound!(
         serialize_certificates,
+        &submod
+    )?)?;
+    submod.add_function(pyo3::wrap_pyfunction_bound!(
+        encrypt_and_serialize,
         &submod
     )?)?;
     submod.add_function(pyo3::wrap_pyfunction_bound!(sign_and_serialize, &submod)?)?;

--- a/src/rust/src/pkcs7.rs
+++ b/src/rust/src/pkcs7.rs
@@ -119,16 +119,14 @@ fn encrypt_and_serialize<'p>(
         .extract()?;
 
     let mut recipient_infos = vec![];
+    let padding = types::PKCS1V15.get(py)?.call0()?;
     let ka_bytes = cryptography_keepalive::KeepAlive::new();
     for cert in py_recipients.iter() {
         // Currently, keys are encrypted with RSA (PKCS #1 v1.5), which the S/MIME v3.2 RFC
         // specifies as MUST support (https://datatracker.ietf.org/doc/html/rfc5751#section-2.3)
         let encrypted_key = cert
             .call_method0(pyo3::intern!(py, "public_key"))?
-            .call_method1(
-                pyo3::intern!(py, "encrypt"),
-                (&key, types::PKCS1V15.get(py)?.call0()?),
-            )?
+            .call_method1(pyo3::intern!(py, "encrypt"), (&key, &padding))?
             .extract::<pyo3::pybacked::PyBackedBytes>()?;
 
         recipient_infos.push(pkcs7::RecipientInfo {

--- a/src/rust/src/types.rs
+++ b/src/rust/src/types.rs
@@ -324,9 +324,14 @@ pub static PKCS7_DETACHED_SIGNATURE: LazyPyImport = LazyPyImport::new(
     &["PKCS7Options", "DetachedSignature"],
 );
 
-pub static SMIME_ENCODE: LazyPyImport = LazyPyImport::new(
+pub static SMIME_ENVELOPED_ENCODE: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.primitives.serialization.pkcs7",
-    &["_smime_encode"],
+    &["_smime_enveloped_encode"],
+);
+
+pub static SMIME_SIGNED_ENCODE: LazyPyImport = LazyPyImport::new(
+    "cryptography.hazmat.primitives.serialization.pkcs7",
+    &["_smime_signed_encode"],
 );
 
 pub static PKCS12KEYANDCERTIFICATES: LazyPyImport = LazyPyImport::new(
@@ -352,6 +357,8 @@ pub static PREHASHED: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.primitives.asymmetric.utils",
     &["Prehashed"],
 );
+pub static SYMMETRIC_PADDING_PKCS7: LazyPyImport =
+    LazyPyImport::new("cryptography.hazmat.primitives.padding", &["PKCS7"]);
 pub static ASYMMETRIC_PADDING: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.primitives.asymmetric.padding",
     &["AsymmetricPadding"],
@@ -455,6 +462,9 @@ pub static FFI_CAST: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.bindings._rust",
     &["_openssl", "ffi", "cast"],
 );
+
+pub static CIPHER: LazyPyImport =
+    LazyPyImport::new("cryptography.hazmat.primitives.ciphers", &["Cipher"]);
 
 pub static BLOCK_CIPHER_ALGORITHM: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.primitives.ciphers",

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -923,8 +923,10 @@ def _load_rsa_cert_key():
 
 
 @pytest.mark.supported(
-    only_if=lambda backend: backend.pkcs7_supported(),
-    skip_message="Requires OpenSSL with PKCS7 support",
+    only_if=lambda backend: backend.pkcs7_supported()
+    and backend.rsa_encryption_supported(padding.PKCS1v15()),
+    skip_message="Requires OpenSSL with PKCS7 support and PKCS1 v1.5 padding "
+    "support",
 )
 class TestPKCS7EnvelopeBuilder:
     def test_invalid_data(self, backend):
@@ -1151,3 +1153,14 @@ class TestPKCS7Unsupported:
 
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_SERIALIZATION):
             pkcs7.load_pem_pkcs7_certificates(b"nonsense")
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.pkcs7_supported()
+    and not backend.rsa_encryption_supported(padding.PKCS1v15()),
+    skip_message="Requires OpenSSL with no PKCS1 v1.5 padding support",
+)
+class TestPKCS7EnvelopeBuilderUnsupported:
+    def test_envelope_builder_unsupported(self, backend):
+        with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_PADDING):
+            pkcs7.PKCS7EnvelopeBuilder()

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -997,13 +997,21 @@ class TestPKCS7EnvelopeBuilder:
         with pytest.raises(ValueError):
             builder.encrypt(serialization.Encoding.DER, [invalid_option])
 
-    def test_smime_encrypt_smime_encoding(self, backend):
+    @pytest.mark.parametrize(
+        "options",
+        [
+            [pkcs7.PKCS7Options.Text],
+            [pkcs7.PKCS7Options.Binary],
+            [pkcs7.PKCS7Options.Text, pkcs7.PKCS7Options.Binary],
+        ],
+    )
+    def test_smime_encrypt_smime_encoding(self, backend, options):
         data = b"hello world\n"
         cert, _ = _load_rsa_cert_key()
         builder = (
             pkcs7.PKCS7EnvelopeBuilder().set_data(data).add_recipient(cert)
         )
-        enveloped = builder.encrypt(serialization.Encoding.SMIME, [])
+        enveloped = builder.encrypt(serialization.Encoding.SMIME, options)
         assert b"MIME-Version: 1.0\n" in enveloped
         assert b"Content-Transfer-Encoding: base64\n" in enveloped
         message = email.parser.BytesParser().parsebytes(enveloped)
@@ -1028,13 +1036,21 @@ class TestPKCS7EnvelopeBuilder:
             b"\x20\x43\x41"
         ) in payload
 
-    def test_smime_encrypt_der_encoding(self, backend):
+    @pytest.mark.parametrize(
+        "options",
+        [
+            [pkcs7.PKCS7Options.Text],
+            [pkcs7.PKCS7Options.Binary],
+            [pkcs7.PKCS7Options.Text, pkcs7.PKCS7Options.Binary],
+        ],
+    )
+    def test_smime_encrypt_der_encoding(self, backend, options):
         data = b"hello world\n"
         cert, _ = _load_rsa_cert_key()
         builder = (
             pkcs7.PKCS7EnvelopeBuilder().set_data(data).add_recipient(cert)
         )
-        enveloped = builder.encrypt(serialization.Encoding.DER, [])
+        enveloped = builder.encrypt(serialization.Encoding.DER, options)
 
         # We want to know if we've serialized something that has the parameters
         # we expect, so we match on specific byte strings of OIDs & DER values.


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#10889](https://togithub.com/pyca/cryptography/pull/10889).



The original branch is fork-10889-trail-of-forks/smime-encryption