### PR TITLE
Migrate PKCS#12 serialization with keys to Rust

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -406,14 +406,8 @@ class Backend:
         if name is not None:
             utils._check_bytes("name", name)
 
-        if isinstance(encryption_algorithm, serialization.NoEncryption):
-            nid_cert = -1
-            nid_key = -1
-            pkcs12_iter = 0
-            # mac_iter of 0 uses OpenSSL's default value
-            mac_iter = 0
-            mac_alg = self._ffi.NULL
-        elif isinstance(
+        assert not isinstance(encryption_algorithm, serialization.NoEncryption)
+        if isinstance(
             encryption_algorithm, serialization.BestAvailableEncryption
         ):
             # PKCS12 encryption is hopeless trash and can never be fixed.

--- a/src/cryptography/hazmat/bindings/_rust/pkcs12.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/pkcs12.pyi
@@ -8,6 +8,7 @@ from cryptography import x509
 from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
 from cryptography.hazmat.primitives.serialization.pkcs12 import (
     PKCS12KeyAndCertificates,
+    PKCS12PrivateKeyTypes,
 )
 
 class PKCS12Certificate:
@@ -35,6 +36,7 @@ def load_pkcs12(
 ) -> PKCS12KeyAndCertificates: ...
 def serialize_key_and_certificates(
     name: bytes | None,
+    key: PKCS12PrivateKeyTypes | None,
     cert: x509.Certificate | None,
     cas: typing.Iterable[x509.Certificate | PKCS12Certificate] | None,
 ) -> bytes: ...

--- a/src/cryptography/hazmat/primitives/serialization/pkcs12.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs12.py
@@ -167,10 +167,8 @@ def serialize_key_and_certificates(
     if key is None and cert is None and not cas:
         raise ValueError("You must supply at least one of key, cert, or cas")
 
-    if key is None and isinstance(
-        encryption_algorithm, serialization.NoEncryption
-    ):
-        return rust_pkcs12.serialize_key_and_certificates(name, cert, cas)
+    if isinstance(encryption_algorithm, serialization.NoEncryption):
+        return rust_pkcs12.serialize_key_and_certificates(name, key, cert, cas)
 
     from cryptography.hazmat.backends.openssl.backend import backend
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#10901](https://togithub.com/pyca/cryptography/pull/10901).



The original branch is fork-10901-alex/minimal-pkcs12