### PR TITLE
Bump virtualenv from 20.26.0 to 20.26.1

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -150,7 +150,7 @@ typing-extensions==4.11.0; python_version >= "3.8"
     # via mypy
 urllib3==2.2.1
     # via requests
-virtualenv==20.26.0
+virtualenv==20.26.1
     # via nox
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#10908](https://togithub.com/pyca/cryptography/pull/10908).



The original branch is upstream/dependabot/pip/virtualenv-20.26.1