### PR TITLE
Bump docutils from 0.20.1 to 0.21.2

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -31,7 +31,7 @@ coverage==7.6.1; python_version >= "3.8"
     #   pytest-cov
 distlib==0.3.8
     # via virtualenv
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   readme-renderer
     #   sphinx


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#10925](https://togithub.com/pyca/cryptography/pull/10925).



The original branch is upstream/dependabot/pip/docutils-0.21.2