### PR TITLE
Bump actions/download-artifact from 3.0.2 to 4.1.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,7 +432,7 @@ jobs:
         if: ${{ always() }}
       - name: Download coverage data
         if: ${{ always() }}
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           pattern: coverage-data-*
           merge-multiple: true


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#10924](https://togithub.com/pyca/cryptography/pull/10924).



The original branch is upstream/dependabot/github_actions/actions/download-artifact-4.1.7