### PR TITLE
Bump pygments from 2.17.2 to 2.18.0

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -80,7 +80,7 @@ pyenchant==3.2.2
     # via
     #   cryptography (pyproject.toml)
     #   sphinxcontrib-spelling
-pygments==2.17.2
+pygments==2.18.0
     # via
     #   readme-renderer
     #   sphinx


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#10938](https://togithub.com/pyca/cryptography/pull/10938).



The original branch is upstream/dependabot/pip/pygments-2.18.0