### PR TITLE
Bump cc from 1.0.96 to 1.0.97 in /src/rust

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -42,9 +42,9 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "cc"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
 
 [[package]]
 name = "cfg-if"

--- a/src/rust/cryptography-cffi/Cargo.toml
+++ b/src/rust/cryptography-cffi/Cargo.toml
@@ -12,4 +12,4 @@ pyo3 = { version = "0.21.2", features = ["abi3"] }
 openssl-sys = "0.9.102"
 
 [build-dependencies]
-cc = "1.0.96"
+cc = "1.0.97"


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#10945](https://togithub.com/pyca/cryptography/pull/10945).



The original branch is upstream/dependabot/cargo/src/rust/cc-1.0.97