### PR TITLE
Bump jinja2 from 3.1.3 to 3.1.4

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -48,7 +48,7 @@ imagesize==1.4.1
     # via sphinx
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.3
+jinja2==3.1.4
     # via sphinx
 markupsafe==2.1.5
     # via jinja2


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#10946](https://togithub.com/pyca/cryptography/pull/10946).



The original branch is upstream/dependabot/pip/jinja2-3.1.4