### PR TITLE
Bump actions/attest-build-provenance from 1.0.0 to 1.1.0

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -93,7 +93,7 @@ jobs:
       # Do not perform attestation for things for TestPyPI. This is because
       # there's nothing that would prevent a malicious PyPI from serving a
       # signed TestPyPI asset in place of a release intended for PyPI.
-      - uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940  # v1.0.0
+      - uses: actions/attest-build-provenance@f8d5ea8082b0d9f5ab855907be308fbd7eefb155  # v1.1.0
         with:
           subject-path: 'dist/**/cryptography*'
         if: env.TWINE_REPOSITORY == 'pypi'


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#10951](https://togithub.com/pyca/cryptography/pull/10951).



The original branch is upstream/dependabot/github_actions/actions/attest-build-provenance-1.1.0