### PR TITLE
Implement encrypted PKCS#12 serialization in Rust

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -398,26 +398,7 @@ class Backend:
         if name is not None:
             utils._check_bytes("name", name)
 
-        assert not isinstance(encryption_algorithm, serialization.NoEncryption)
-        if isinstance(
-            encryption_algorithm, serialization.BestAvailableEncryption
-        ):
-            # PKCS12 encryption is hopeless trash and can never be fixed.
-            # OpenSSL 3 supports PBESv2, but Libre and Boring do not, so
-            # we use PBESv1 with 3DES on the older paths.
-            if rust_openssl.CRYPTOGRAPHY_OPENSSL_300_OR_GREATER:
-                nid_cert = self._lib.NID_aes_256_cbc
-                nid_key = self._lib.NID_aes_256_cbc
-            else:
-                nid_cert = self._lib.NID_pbe_WithSHA1And3_Key_TripleDES_CBC
-                nid_key = self._lib.NID_pbe_WithSHA1And3_Key_TripleDES_CBC
-            # At least we can set this higher than OpenSSL's default
-            pkcs12_iter = 20000
-            mac_iter = 0
-            # MAC algorithm can only be set on OpenSSL 3.0.0+
-            mac_alg = self._ffi.NULL
-            password = encryption_algorithm.password
-        elif (
+        if (
             isinstance(
                 encryption_algorithm, serialization._KeySerializationEncryption
             )

--- a/src/cryptography/hazmat/primitives/serialization/pkcs12.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs12.py
@@ -167,7 +167,11 @@ def serialize_key_and_certificates(
     if key is None and cert is None and not cas:
         raise ValueError("You must supply at least one of key, cert, or cas")
 
-    if isinstance(encryption_algorithm, serialization.NoEncryption):
+    if isinstance(
+        encryption_algorithm, serialization.NoEncryption
+    ) or isinstance(
+        encryption_algorithm, serialization.BestAvailableEncryption
+    ):
         return rust_pkcs12.serialize_key_and_certificates(
             name, key, cert, cas, encryption_algorithm
         )

--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -125,6 +125,12 @@ pub enum AlgorithmParameters<'a> {
     #[defined_by(oid::DH_KEY_AGREEMENT_OID)]
     DhKeyAgreement(BasicDHParams<'a>),
 
+    #[defined_by(oid::PBES2_OID)]
+    Pbes2(PBES2Params<'a>),
+
+    #[defined_by(oid::PBKDF2_OID)]
+    Pbkdf2(PBKDF2Params<'a>),
+
     #[defined_by(oid::HMAC_WITH_SHA1_OID)]
     HmacWithSha1(asn1::Null),
     #[defined_by(oid::HMAC_WITH_SHA256_OID)]
@@ -401,6 +407,28 @@ pub struct DssParams<'a> {
     pub p: asn1::BigUint<'a>,
     pub q: asn1::BigUint<'a>,
     pub g: asn1::BigUint<'a>,
+}
+
+#[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Eq, Hash, Clone, Debug)]
+pub struct PBES2Params<'a> {
+    pub key_derivation_func: Box<AlgorithmIdentifier<'a>>,
+    pub encryption_scheme: Box<AlgorithmIdentifier<'a>>,
+}
+
+const HMAC_SHA1_ALG: AlgorithmIdentifier<'static> = AlgorithmIdentifier {
+    oid: asn1::DefinedByMarker::marker(),
+    params: AlgorithmParameters::HmacWithSha1(()),
+};
+
+#[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Eq, Hash, Clone, Debug)]
+pub struct PBKDF2Params<'a> {
+    // This is technically a CHOICE that can be an otherSource. We don't
+    // support that.
+    pub salt: &'a [u8],
+    pub iteration_count: u64,
+    pub key_length: Option<u64>,
+    #[default(HMAC_SHA1_ALG)]
+    pub prf: Box<AlgorithmIdentifier<'a>>,
 }
 
 /// A VisibleString ASN.1 element whose contents is not validated as meeting the

--- a/src/rust/cryptography-x509/src/pkcs12.rs
+++ b/src/rust/cryptography-x509/src/pkcs12.rs
@@ -2,7 +2,7 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use crate::common::Utf8StoredBMPString;
+use crate::common::{AlgorithmIdentifier, Utf8StoredBMPString};
 use crate::pkcs7;
 
 pub const CERT_BAG_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 12, 10, 1, 3);
@@ -55,6 +55,9 @@ pub enum BagValue<'a> {
 
     #[defined_by(KEY_BAG_OID)]
     KeyBag(asn1::Tlv<'a>),
+
+    #[defined_by(SHROUDED_KEY_BAG_OID)]
+    ShroudedKeyBag(EncryptedPrivateKeyInfo<'a>),
 }
 
 #[derive(asn1::Asn1Write)]
@@ -68,4 +71,10 @@ pub struct CertBag<'a> {
 pub enum CertType<'a> {
     #[defined_by(X509_CERTIFICATE_OID)]
     X509(asn1::OctetStringEncoded<crate::certificate::Certificate<'a>>),
+}
+
+#[derive(asn1::Asn1Write)]
+pub struct EncryptedPrivateKeyInfo<'a> {
+    pub encryption_algorithm: AlgorithmIdentifier<'a>,
+    pub encrypted_data: &'a [u8],
 }

--- a/src/rust/cryptography-x509/src/pkcs7.rs
+++ b/src/rust/cryptography-x509/src/pkcs7.rs
@@ -22,6 +22,8 @@ pub enum Content<'a> {
     SignedData(asn1::Explicit<Box<SignedData<'a>>, 0>),
     #[defined_by(PKCS7_DATA_OID)]
     Data(Option<asn1::Explicit<&'a [u8], 0>>),
+    #[defined_by(PKCS7_ENCRYPTED_DATA_OID)]
+    EncryptedData(asn1::Explicit<EncryptedData<'a>, 0>),
 }
 
 #[derive(asn1::Asn1Write)]
@@ -58,6 +60,20 @@ pub struct SignerInfo<'a> {
 pub struct IssuerAndSerialNumber<'a> {
     pub issuer: name::Name<'a>,
     pub serial_number: asn1::BigInt<'a>,
+}
+
+#[derive(asn1::Asn1Write)]
+pub struct EncryptedData<'a> {
+    pub version: u8,
+    pub encrypted_content_info: EncryptedContentInfo<'a>,
+}
+
+#[derive(asn1::Asn1Write)]
+pub struct EncryptedContentInfo<'a> {
+    pub content_type: asn1::ObjectIdentifier,
+    pub content_encryption_algorithm: common::AlgorithmIdentifier<'a>,
+    #[implicit(0)]
+    pub encrypted_content: Option<&'a [u8]>,
 }
 
 #[derive(asn1::Asn1Write)]

--- a/src/rust/src/backend/ciphers.rs
+++ b/src/rust/src/backend/ciphers.rs
@@ -10,13 +10,13 @@ use crate::types;
 use pyo3::prelude::{PyAnyMethods, PyModuleMethods};
 use pyo3::IntoPy;
 
-struct CipherContext {
+pub(crate) struct CipherContext {
     ctx: openssl::cipher_ctx::CipherCtx,
     py_mode: pyo3::PyObject,
 }
 
 impl CipherContext {
-    fn new(
+    pub(crate) fn new(
         py: pyo3::Python<'_>,
         algorithm: pyo3::Bound<'_, pyo3::PyAny>,
         mode: pyo3::Bound<'_, pyo3::PyAny>,
@@ -126,7 +126,7 @@ impl CipherContext {
         Ok(pyo3::types::PyBytes::new_bound(py, &out_buf[..n]))
     }
 
-    fn update_into(
+    pub(crate) fn update_into(
         &mut self,
         py: pyo3::Python<'_>,
         buf: &[u8],
@@ -167,7 +167,7 @@ impl CipherContext {
         Ok(())
     }
 
-    fn finalize<'p>(
+    pub(crate) fn finalize<'p>(
         &mut self,
         py: pyo3::Python<'p>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -8,7 +8,7 @@ use crate::error::CryptographyResult;
 use pyo3::prelude::PyModuleMethods;
 
 #[pyo3::prelude::pyfunction]
-fn derive_pbkdf2_hmac<'p>(
+pub(crate) fn derive_pbkdf2_hmac<'p>(
     py: pyo3::Python<'p>,
     key_material: CffiBuf<'_>,
     algorithm: &pyo3::Bound<'_, pyo3::PyAny>,

--- a/src/rust/src/buf.rs
+++ b/src/rust/src/buf.rs
@@ -35,6 +35,14 @@ fn _extract_buffer_length<'p>(
 }
 
 impl<'a> CffiBuf<'a> {
+    pub(crate) fn from_bytes(py: pyo3::Python<'a>, buf: &'a [u8]) -> Self {
+        CffiBuf {
+            pyobj: py.None().into_bound(py),
+            _bufobj: py.None().into_bound(py),
+            buf,
+        }
+    }
+
     pub(crate) fn as_bytes(&self) -> &[u8] {
         self.buf
     }

--- a/src/rust/src/padding.rs
+++ b/src/rust/src/padding.rs
@@ -76,14 +76,17 @@ pub(crate) struct PKCS7PaddingContext {
 #[pyo3::prelude::pymethods]
 impl PKCS7PaddingContext {
     #[new]
-    fn new(block_size: usize) -> PKCS7PaddingContext {
+    pub(crate) fn new(block_size: usize) -> PKCS7PaddingContext {
         PKCS7PaddingContext {
             block_size: block_size / 8,
             length_seen: Some(0),
         }
     }
 
-    fn update<'a>(&mut self, buf: CffiBuf<'a>) -> CryptographyResult<pyo3::Bound<'a, pyo3::PyAny>> {
+    pub(crate) fn update<'a>(
+        &mut self,
+        buf: CffiBuf<'a>,
+    ) -> CryptographyResult<pyo3::Bound<'a, pyo3::PyAny>> {
         match self.length_seen.as_mut() {
             Some(v) => {
                 *v += buf.as_bytes().len();
@@ -95,7 +98,7 @@ impl PKCS7PaddingContext {
         }
     }
 
-    fn finalize<'p>(
+    pub(crate) fn finalize<'p>(
         &mut self,
         py: pyo3::Python<'p>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {

--- a/src/rust/src/pkcs12.rs
+++ b/src/rust/src/pkcs12.rs
@@ -2,9 +2,10 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use crate::backend::{hashes, hmac, keys};
+use crate::backend::{ciphers, hashes, hmac, kdf, keys};
 use crate::buf::CffiBuf;
 use crate::error::CryptographyResult;
+use crate::padding::PKCS7PaddingContext;
 use crate::x509::certificate::Certificate;
 use crate::{types, x509};
 use cryptography_x509::common::Utf8StoredBMPString;
@@ -74,6 +75,94 @@ impl PKCS12Certificate {
             self.certificate.bind(py).str()?,
             friendly_name_repr
         ))
+    }
+}
+
+enum EncryptionAlgorithm {
+    PBESv2SHA256AndAES256CBC,
+}
+
+impl EncryptionAlgorithm {
+    fn algorithm_identifier<'a>(
+        &self,
+        salt: &'a [u8],
+        iv: &'a [u8],
+    ) -> cryptography_x509::common::AlgorithmIdentifier<'a> {
+        match self {
+            EncryptionAlgorithm::PBESv2SHA256AndAES256CBC => {
+                let kdf_algorithm_identifier = cryptography_x509::common::AlgorithmIdentifier {
+                    oid: asn1::DefinedByMarker::marker(),
+                    params: cryptography_x509::common::AlgorithmParameters::Pbkdf2(
+                        cryptography_x509::common::PBKDF2Params {
+                            salt,
+                            iteration_count: 20000,
+                            key_length: None,
+                            prf: Box::new(cryptography_x509::common::AlgorithmIdentifier {
+                                oid: asn1::DefinedByMarker::marker(),
+                                params:
+                                    cryptography_x509::common::AlgorithmParameters::HmacWithSha256(
+                                        (),
+                                    ),
+                            }),
+                        },
+                    ),
+                };
+                let encryption_algorithm_identifier =
+                    cryptography_x509::common::AlgorithmIdentifier {
+                        oid: asn1::DefinedByMarker::marker(),
+                        params: cryptography_x509::common::AlgorithmParameters::Aes256Cbc(
+                            iv[..16].try_into().unwrap(),
+                        ),
+                    };
+
+                cryptography_x509::common::AlgorithmIdentifier {
+                    oid: asn1::DefinedByMarker::marker(),
+                    params: cryptography_x509::common::AlgorithmParameters::Pbes2(
+                        cryptography_x509::common::PBES2Params {
+                            key_derivation_func: Box::new(kdf_algorithm_identifier),
+                            encryption_scheme: Box::new(encryption_algorithm_identifier),
+                        },
+                    ),
+                }
+            }
+        }
+    }
+
+    fn encrypt(
+        &self,
+        py: pyo3::Python<'_>,
+        password: &[u8],
+        salt: &[u8],
+        iv: &[u8],
+        data: &[u8],
+    ) -> CryptographyResult<Vec<u8>> {
+        match self {
+            EncryptionAlgorithm::PBESv2SHA256AndAES256CBC => {
+                let pass_buf = CffiBuf::from_bytes(py, password);
+                let sha256 = types::SHA256.get(py)?.call0()?;
+
+                let key = kdf::derive_pbkdf2_hmac(py, pass_buf, &sha256, salt, 20000, 32)?;
+
+                let aes256 = types::AES256.get(py)?.call1((key,))?;
+                let cbc = types::CBC.get(py)?.call1((iv,))?;
+                let mut cipher =
+                    ciphers::CipherContext::new(py, aes256, cbc, openssl::symm::Mode::Encrypt)?;
+
+                let mut ciphertext = vec![0; data.len() + 32];
+                let n = cipher.update_into(py, data, &mut ciphertext)?;
+
+                let mut padder = PKCS7PaddingContext::new(128);
+                assert!(padder.update(CffiBuf::from_bytes(py, data))?.is_none());
+                let padding = padder.finalize(py)?;
+
+                let pad_n = cipher.update_into(py, padding.as_bytes(), &mut ciphertext[n..])?;
+                let final_block = cipher.finalize(py)?;
+                assert!(final_block.as_bytes().is_empty());
+                ciphertext.truncate(n + pad_n);
+
+                Ok(ciphertext)
+            }
+        }
     }
 }
 
@@ -237,16 +326,29 @@ fn decode_encryption_algorithm<'a>(
     pyo3::pybacked::PyBackedBytes,
     pyo3::Bound<'a, pyo3::PyAny>,
     u64,
+    Option<EncryptionAlgorithm>,
 )> {
     let default_hmac_alg = types::SHA256.get(py)?.call0()?;
     let default_hmac_kdf_iter = 2048;
 
-    assert!(encryption_algorithm.is_instance(&types::NO_ENCRYPTION.get(py)?)?);
-    Ok((
-        pyo3::types::PyBytes::new_bound(py, b"").extract()?,
-        default_hmac_alg,
-        default_hmac_kdf_iter,
-    ))
+    if encryption_algorithm.is_instance(&types::NO_ENCRYPTION.get(py)?)? {
+        Ok((
+            pyo3::types::PyBytes::new_bound(py, b"").extract()?,
+            default_hmac_alg,
+            default_hmac_kdf_iter,
+            None,
+        ))
+    } else {
+        assert!(encryption_algorithm.is_instance(&types::BEST_AVAILABLE_ENCRYPTION.get(py)?)?);
+        Ok((
+            encryption_algorithm
+                .getattr(pyo3::intern!(py, "password"))?
+                .extract()?,
+            default_hmac_alg,
+            default_hmac_kdf_iter,
+            Some(EncryptionAlgorithm::PBESv2SHA256AndAES256CBC),
+        ))
+    }
 }
 
 #[derive(pyo3::FromPyObject)]
@@ -265,11 +367,20 @@ fn serialize_key_and_certificates<'p>(
     cas: Option<pyo3::Bound<'_, pyo3::PyAny>>,
     encryption_algorithm: pyo3::Bound<'_, pyo3::PyAny>,
 ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
-    let (password, mac_algorithm, mac_kdf_iter) =
+    let (password, mac_algorithm, mac_kdf_iter, encryption_algorithm) =
         decode_encryption_algorithm(py, encryption_algorithm)?;
 
     let mut auth_safe_contents = vec![];
-    let (cert_bag_contents, key_bag_contents);
+    let (
+        cert_bag_contents,
+        cert_salt,
+        cert_iv,
+        cert_ciphertext,
+        key_bag_contents,
+        key_salt,
+        key_iv,
+        key_ciphertext,
+    );
     let mut ca_certs = vec![];
     if cert.is_some() || cas.is_some() {
         let mut cert_bags = vec![];
@@ -296,12 +407,39 @@ fn serialize_key_and_certificates<'p>(
         }
 
         cert_bag_contents = asn1::write_single(&asn1::SequenceOfWriter::new(cert_bags))?;
-        auth_safe_contents.push(cryptography_x509::pkcs7::ContentInfo {
-            _content_type: asn1::DefinedByMarker::marker(),
-            content: cryptography_x509::pkcs7::Content::Data(Some(asn1::Explicit::new(
-                &cert_bag_contents,
-            ))),
-        });
+        if let Some(e) = &encryption_algorithm {
+            cert_salt = types::OS_URANDOM
+                .get(py)?
+                .call1((16,))?
+                .extract::<pyo3::pybacked::PyBackedBytes>()?;
+            cert_iv = types::OS_URANDOM
+                .get(py)?
+                .call1((16,))?
+                .extract::<pyo3::pybacked::PyBackedBytes>()?;
+            cert_ciphertext = e.encrypt(py, &password, &cert_salt, &cert_iv, &cert_bag_contents)?;
+
+            auth_safe_contents.push(cryptography_x509::pkcs7::ContentInfo {
+                _content_type: asn1::DefinedByMarker::marker(),
+                content: cryptography_x509::pkcs7::Content::EncryptedData(asn1::Explicit::new(
+                    cryptography_x509::pkcs7::EncryptedData {
+                        version: 0,
+                        encrypted_content_info: cryptography_x509::pkcs7::EncryptedContentInfo {
+                            content_type: cryptography_x509::pkcs7::PKCS7_DATA_OID,
+                            content_encryption_algorithm: e
+                                .algorithm_identifier(&cert_salt, &cert_iv),
+                            encrypted_content: Some(&cert_ciphertext),
+                        },
+                    },
+                )),
+            })
+        } else {
+            auth_safe_contents.push(cryptography_x509::pkcs7::ContentInfo {
+                _content_type: asn1::DefinedByMarker::marker(),
+                content: cryptography_x509::pkcs7::Content::Data(Some(asn1::Explicit::new(
+                    &cert_bag_contents,
+                ))),
+            });
+        }
     }
 
     if let Some(key) = key {
@@ -315,12 +453,40 @@ fn serialize_key_and_certificates<'p>(
                 (der, pkcs8, no_encryption),
             )?
             .extract::<pyo3::pybacked::PyBackedBytes>()?;
-        let pkcs8_tlv = asn1::parse_single(&pkcs8_bytes)?;
 
-        let key_bag = cryptography_x509::pkcs12::SafeBag {
-            _bag_id: asn1::DefinedByMarker::marker(),
-            bag_value: asn1::Explicit::new(cryptography_x509::pkcs12::BagValue::KeyBag(pkcs8_tlv)),
-            attributes: friendly_name_attributes(name)?,
+        let key_bag = if let Some(e) = encryption_algorithm {
+            key_salt = types::OS_URANDOM
+                .get(py)?
+                .call1((16,))?
+                .extract::<pyo3::pybacked::PyBackedBytes>()?;
+            key_iv = types::OS_URANDOM
+                .get(py)?
+                .call1((16,))?
+                .extract::<pyo3::pybacked::PyBackedBytes>()?;
+            key_ciphertext = e.encrypt(py, &password, &key_salt, &key_iv, &pkcs8_bytes)?;
+
+            cryptography_x509::pkcs12::SafeBag {
+                _bag_id: asn1::DefinedByMarker::marker(),
+                bag_value: asn1::Explicit::new(
+                    cryptography_x509::pkcs12::BagValue::ShroudedKeyBag(
+                        cryptography_x509::pkcs12::EncryptedPrivateKeyInfo {
+                            encryption_algorithm: e.algorithm_identifier(&key_salt, &key_iv),
+                            encrypted_data: &key_ciphertext,
+                        },
+                    ),
+                ),
+                attributes: friendly_name_attributes(name)?,
+            }
+        } else {
+            let pkcs8_tlv = asn1::parse_single(&pkcs8_bytes)?;
+
+            cryptography_x509::pkcs12::SafeBag {
+                _bag_id: asn1::DefinedByMarker::marker(),
+                bag_value: asn1::Explicit::new(cryptography_x509::pkcs12::BagValue::KeyBag(
+                    pkcs8_tlv,
+                )),
+                attributes: friendly_name_attributes(name)?,
+            }
         };
 
         key_bag_contents = asn1::write_single(&asn1::SequenceOfWriter::new([key_bag]))?;


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11059](https://togithub.com/pyca/cryptography/pull/11059).



The original branch is fork-11059-alex/pkcs12-basic-encryption