### PR TITLE
Bump readme-renderer from 43.0 to 44.0

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -101,7 +101,7 @@ pytest-randomly==3.15.0
     # via cryptography (pyproject.toml)
 pytest-xdist==3.6.1; python_version >= "3.8"
     # via cryptography (pyproject.toml)
-readme-renderer==43.0
+readme-renderer==44.0
     # via cryptography (pyproject.toml)
 requests==2.32.3
     # via sphinx


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11226](https://togithub.com/pyca/cryptography/pull/11226).



The original branch is upstream/dependabot/pip/readme-renderer-44.0