### PR TITLE
Bump setuptools from 70.3.0 to 71.0.0 in /.github/requirements

### DIFF
--- a/.github/requirements/build-requirements.txt
+++ b/.github/requirements/build-requirements.txt
@@ -83,7 +83,7 @@ tomli==2.0.1 \
     # via maturin
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==70.3.0 \
-    --hash=sha256:f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5 \
-    --hash=sha256:fe384da74336c398e0d956d1cae0669bc02eed936cdb1d49b57de1990dc11ffc
+setuptools==71.0.0 \
+    --hash=sha256:98da3b8aca443b9848a209ae4165e2edede62633219afa493a58fbba57f72e2e \
+    --hash=sha256:f06fbe978a91819d250a30e0dc4ca79df713d909e24438a42d0ec300fc52247f
     # via -r build-requirements.in


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11293](https://togithub.com/pyca/cryptography/pull/11293).



The original branch is upstream/dependabot/pip/dot-github/requirements/setuptools-71.0.0