### PR TITLE
Bump setuptools from 71.0.0 to 71.0.1 in /.github/requirements

### DIFF
--- a/.github/requirements/build-requirements.txt
+++ b/.github/requirements/build-requirements.txt
@@ -83,7 +83,7 @@ tomli==2.0.1 \
     # via maturin
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==71.0.0 \
-    --hash=sha256:98da3b8aca443b9848a209ae4165e2edede62633219afa493a58fbba57f72e2e \
-    --hash=sha256:f06fbe978a91819d250a30e0dc4ca79df713d909e24438a42d0ec300fc52247f
+setuptools==71.0.1 \
+    --hash=sha256:1eb8ef012efae7f6acbc53ec0abde4bc6746c43087fd215ee09e1df48998711f \
+    --hash=sha256:c51d7fd29843aa18dad362d4b4ecd917022131425438251f4e3d766c964dd1ad
     # via -r build-requirements.in


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11295](https://togithub.com/pyca/cryptography/pull/11295).



The original branch is upstream/dependabot/pip/dot-github/requirements/setuptools-71.0.1