### PR TITLE
Bump setuptools from 71.0.1 to 71.0.3 in /.github/requirements

### DIFF
--- a/.github/requirements/build-requirements.txt
+++ b/.github/requirements/build-requirements.txt
@@ -83,7 +83,7 @@ tomli==2.0.1 \
     # via maturin
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==71.0.1 \
-    --hash=sha256:1eb8ef012efae7f6acbc53ec0abde4bc6746c43087fd215ee09e1df48998711f \
-    --hash=sha256:c51d7fd29843aa18dad362d4b4ecd917022131425438251f4e3d766c964dd1ad
+setuptools==71.0.3 \
+    --hash=sha256:3d8531791a27056f4a38cd3e54084d8b1c4228ff9cf3f2d7dd075ec99f9fd70d \
+    --hash=sha256:f501b6e6db709818dc76882582d9c516bf3b67b948864c5fa1d1624c09a49207
     # via -r build-requirements.in


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11300](https://togithub.com/pyca/cryptography/pull/11300).



The original branch is upstream/dependabot/pip/dot-github/requirements/setuptools-71.0.3