### PR TITLE
Bump setuptools from 71.0.3 to 71.0.4 in /.github/requirements

### DIFF
--- a/.github/requirements/build-requirements.txt
+++ b/.github/requirements/build-requirements.txt
@@ -83,7 +83,7 @@ tomli==2.0.1 \
     # via maturin
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==71.0.3 \
-    --hash=sha256:3d8531791a27056f4a38cd3e54084d8b1c4228ff9cf3f2d7dd075ec99f9fd70d \
-    --hash=sha256:f501b6e6db709818dc76882582d9c516bf3b67b948864c5fa1d1624c09a49207
+setuptools==71.0.4 \
+    --hash=sha256:48297e5d393a62b7cb2a10b8f76c63a73af933bd809c9e0d0d6352a1a0135dd8 \
+    --hash=sha256:ed2feca703be3bdbd94e6bb17365d91c6935c6b2a8d0bb09b66a2c435ba0b1a5
     # via -r build-requirements.in


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11304](https://togithub.com/pyca/cryptography/pull/11304).



The original branch is upstream/dependabot/pip/dot-github/requirements/setuptools-71.0.4