### PR TITLE
Bump mypy from 1.10.1 to 1.11.0

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -52,7 +52,7 @@ jinja2==3.1.4
     # via sphinx
 markupsafe==2.1.5
     # via jinja2
-mypy==1.10.1
+mypy==1.11.0
     # via cryptography (pyproject.toml)
 mypy-extensions==1.0.0
     # via mypy


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11303](https://togithub.com/pyca/cryptography/pull/11303).



The original branch is upstream/dependabot/pip/mypy-1.11.0