### PR TITLE
Bump sphinxcontrib-qthelp from 1.0.7 to 1.0.8

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -132,7 +132,7 @@ sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==1.0.8
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.10
     # via sphinx


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11307](https://togithub.com/pyca/cryptography/pull/11307).



The original branch is upstream/dependabot/pip/sphinxcontrib-qthelp-1.0.8