### PR TITLE
Bump sphinxcontrib-htmlhelp from 2.0.5 to 2.0.6

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -126,7 +126,7 @@ sphinxcontrib-applehelp==1.0.8
     # via sphinx
 sphinxcontrib-devhelp==1.0.6
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.0.6
     # via sphinx
 sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11306](https://togithub.com/pyca/cryptography/pull/11306).



The original branch is upstream/dependabot/pip/sphinxcontrib-htmlhelp-2.0.6