### PR TITLE
Bump openssl-sys from 0.9.102 to 0.9.103 in /src/rust

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -27,7 +27,7 @@ cryptography-x509-verification = { path = "cryptography-x509-verification" }
 cryptography-openssl = { path = "cryptography-openssl" }
 pem = { version = "3", default-features = false }
 openssl = "0.10.64"
-openssl-sys = "0.9.102"
+openssl-sys = "0.9.103"
 foreign-types-shared = "0.1"
 self_cell = "1"
 

--- a/src/rust/cryptography-cffi/Cargo.toml
+++ b/src/rust/cryptography-cffi/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 pyo3 = { version = "0.22.2", features = ["abi3"] }
-openssl-sys = "0.9.102"
+openssl-sys = "0.9.103"
 
 [build-dependencies]
 cc = "1.1.6"

--- a/src/rust/cryptography-key-parsing/Cargo.toml
+++ b/src/rust/cryptography-key-parsing/Cargo.toml
@@ -10,5 +10,5 @@ rust-version.workspace = true
 asn1 = { version = "0.16.2", default-features = false }
 cfg-if = "1"
 openssl = "0.10.64"
-openssl-sys = "0.9.102"
+openssl-sys = "0.9.103"
 cryptography-x509 = { path = "../cryptography-x509" }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11305](https://togithub.com/pyca/cryptography/pull/11305).



The original branch is upstream/dependabot/cargo/src/rust/openssl-sys-0.9.103