### PR TITLE
bump for 43.0.0 and update changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,14 +3,13 @@ Changelog
 
 .. _v43-0-0:
 
-43.0.0 - `main`_
-~~~~~~~~~~~~~~~~
-
-.. note:: This version is not yet released and is under active development.
+43.0.0 - 2024-07-20
+~~~~~~~~~~~~~~~~~~~
 
 * **BACKWARDS INCOMPATIBLE:** Support for OpenSSL less than 1.1.1e has been
   removed.  Users on older version of OpenSSL will need to upgrade.
 * **BACKWARDS INCOMPATIBLE:** Dropped support for LibreSSL < 3.8.
+* Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.3.1.
 * Updated the minimum supported Rust version (MSRV) to 1.65.0, from 1.63.0.
 * :func:`~cryptography.hazmat.primitives.asymmetric.rsa.generate_private_key`
   now enforces a minimum RSA key size of 1024-bit. Note that 1024-bit is still

--- a/noxfile.py
+++ b/noxfile.py
@@ -169,6 +169,7 @@ def flake(session: nox.Session) -> None:
     # TODO: Ideally there'd be a pip flag to install just our dependencies,
     # but not install us.
     pyproject_data = load_pyproject_toml()
+    install(session, "-e", "vectors/")
     install(
         session,
         *pyproject_data["build-system"]["requires"],
@@ -177,7 +178,6 @@ def flake(session: nox.Session) -> None:
         *pyproject_data["project"]["optional-dependencies"]["ssh"],
         *pyproject_data["project"]["optional-dependencies"]["nox"],
     )
-    install(session, "-e", "vectors/")
 
     session.run("ruff", "check", ".")
     session.run("ruff", "format", "--check", ".")
@@ -258,9 +258,9 @@ def local(session):
         "test"
     ]
     test_dependencies = [
-        x
-        for x in test_dependencies
-        if not x.startswith("cryptography_vectors")
+        dep
+        for dep in test_dependencies
+        if not dep.startswith("cryptography_vectors")
     ]
     install(
         session,

--- a/noxfile.py
+++ b/noxfile.py
@@ -254,23 +254,14 @@ def rust(session: nox.Session) -> None:
 @nox.session(venv_backend="uv")
 def local(session):
     pyproject_data = load_pyproject_toml()
-    test_dependencies = pyproject_data["project"]["optional-dependencies"][
-        "test"
-    ]
-    test_dependencies = [
-        dep
-        for dep in test_dependencies
-        if not dep.startswith("cryptography_vectors")
-    ]
+    install(session, "-e", "./vectors")
     install(
         session,
         *pyproject_data["build-system"]["requires"],
         *pyproject_data["project"]["optional-dependencies"]["pep8test"],
-        *test_dependencies,
+        *pyproject_data["project"]["optional-dependencies"]["test"],
         *pyproject_data["project"]["optional-dependencies"]["ssh"],
         *pyproject_data["project"]["optional-dependencies"]["nox"],
-        "-e",
-        "./vectors/",
         verbose=False,
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -65,8 +65,8 @@ def tests(session: nox.Session) -> None:
             }
         )
 
-    install(session, f".[{extras}]")
     install(session, "-e", "./vectors")
+    install(session, f".[{extras}]")
 
     session.run("pip", "list")
 
@@ -257,7 +257,11 @@ def local(session):
     test_dependencies = pyproject_data["project"]["optional-dependencies"][
         "test"
     ]
-    test_dependencies.remove("cryptography_vectors")
+    test_dependencies = [
+        x
+        for x in test_dependencies
+        if not x.startswith("cryptography_vectors")
+    ]
     install(
         session,
         *pyproject_data["build-system"]["requires"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ build-backend = "maturin"
 
 [project]
 name = "cryptography"
-version = "43.0.0.dev1"
+version = "43.0.0"
 authors = [
     {name = "The Python Cryptographic Authority and individual contributors", email = "cryptography-dev@python.org"}
 ]
@@ -64,7 +64,7 @@ ssh = ["bcrypt >=3.1.5"]
 # All the following are used for our own testing.
 nox = ["nox"]
 test = [
-    "cryptography_vectors",
+    "cryptography_vectors==43.0.0",
     "pytest >=6.2.0",
     "pytest-benchmark",
     "pytest-cov",

--- a/src/cryptography/__about__.py
+++ b/src/cryptography/__about__.py
@@ -10,7 +10,7 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "43.0.0.dev1"
+__version__ = "43.0.0"
 
 
 __author__ = "The Python Cryptographic Authority and individual contributors"

--- a/vectors/cryptography_vectors/__about__.py
+++ b/vectors/cryptography_vectors/__about__.py
@@ -6,4 +6,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "43.0.0.dev1"
+__version__ = "43.0.0"

--- a/vectors/pyproject.toml
+++ b/vectors/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "cryptography_vectors"
-version = "43.0.0.dev1"
+version = "43.0.0"
 authors = [
     {name = "The Python Cryptographic Authority and individual contributors", email = "cryptography-dev@python.org"}
 ]


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11311](https://togithub.com/pyca/cryptography/pull/11311).



The original branch is fork-11311-reaperhulk/43-release