### PR TITLE
reopen for 44

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+.. _v44-0-0:
+
+44.0.0 - `main`_
+~~~~~~~~~~~~~~~~
+
+.. note:: This version is not yet released and is under active development.
+
+
 .. _v43-0-0:
 
 43.0.0 - 2024-07-20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ build-backend = "maturin"
 
 [project]
 name = "cryptography"
-version = "43.0.0"
+version = "44.0.0.dev1"
 authors = [
     {name = "The Python Cryptographic Authority and individual contributors", email = "cryptography-dev@python.org"}
 ]
@@ -64,7 +64,7 @@ ssh = ["bcrypt >=3.1.5"]
 # All the following are used for our own testing.
 nox = ["nox"]
 test = [
-    "cryptography_vectors==43.0.0",
+    "cryptography_vectors",
     "pytest >=6.2.0",
     "pytest-benchmark",
     "pytest-cov",

--- a/src/cryptography/__about__.py
+++ b/src/cryptography/__about__.py
@@ -10,7 +10,7 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "43.0.0"
+__version__ = "44.0.0.dev1"
 
 
 __author__ = "The Python Cryptographic Authority and individual contributors"

--- a/vectors/cryptography_vectors/__about__.py
+++ b/vectors/cryptography_vectors/__about__.py
@@ -6,4 +6,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "43.0.0"
+__version__ = "44.0.0.dev1"

--- a/vectors/pyproject.toml
+++ b/vectors/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "cryptography_vectors"
-version = "43.0.0"
+version = "44.0.0.dev1"
 authors = [
     {name = "The Python Cryptographic Authority and individual contributors", email = "cryptography-dev@python.org"}
 ]


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11312](https://togithub.com/pyca/cryptography/pull/11312).



The original branch is fork-11312-reaperhulk/44-open