### PR TITLE
Bump pytest from 8.2.2 to 8.3.1

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -86,7 +86,7 @@ pygments==2.18.0
     #   sphinx
 pyproject-hooks==1.1.0
     # via build
-pytest==8.2.2; python_version >= "3.8"
+pytest==8.3.1; python_version >= "3.8"
     # via
     #   cryptography (pyproject.toml)
     #   pytest-benchmark


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11316](https://togithub.com/pyca/cryptography/pull/11316).



The original branch is upstream/dependabot/pip/pytest-8.3.1