### PR TITLE
Bump openssl from 0.10.65 to 0.10.66 in /src/rust

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -179,9 +179,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
-version = "0.10.65"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2823eb4c6453ed64055057ea8bd416eda38c71018723869dd043a3b1186115e"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags",
  "cfg-if",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -26,7 +26,7 @@ cryptography-x509 = { path = "cryptography-x509" }
 cryptography-x509-verification = { path = "cryptography-x509-verification" }
 cryptography-openssl = { path = "cryptography-openssl" }
 pem = { version = "3", default-features = false }
-openssl = "0.10.65"
+openssl = "0.10.66"
 openssl-sys = "0.9.103"
 foreign-types-shared = "0.1"
 self_cell = "1"

--- a/src/rust/cryptography-key-parsing/Cargo.toml
+++ b/src/rust/cryptography-key-parsing/Cargo.toml
@@ -9,6 +9,6 @@ rust-version.workspace = true
 [dependencies]
 asn1 = { version = "0.16.2", default-features = false }
 cfg-if = "1"
-openssl = "0.10.65"
+openssl = "0.10.66"
 openssl-sys = "0.9.103"
 cryptography-x509 = { path = "../cryptography-x509" }

--- a/src/rust/cryptography-openssl/Cargo.toml
+++ b/src/rust/cryptography-openssl/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 cfg-if = "1"
-openssl = "0.10.65"
+openssl = "0.10.66"
 ffi = { package = "openssl-sys", version = "0.9.101" }
 foreign-types = "0.3"
 foreign-types-shared = "0.1"


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11320](https://togithub.com/pyca/cryptography/pull/11320).



The original branch is upstream/dependabot/cargo/src/rust/openssl-0.10.66