### PR TITLE
Don't include engine.h when OPENSSL_NO_ENGINE is defined

### DIFF
--- a/src/_cffi_src/openssl/engine.py
+++ b/src/_cffi_src/openssl/engine.py
@@ -5,7 +5,9 @@
 from __future__ import annotations
 
 INCLUDES = """
+#if !defined(OPENSSL_NO_ENGINE) || CRYPTOGRAPHY_IS_LIBRESSL
 #include <openssl/engine.h>
+#endif
 """
 
 TYPES = """


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11328](https://togithub.com/pyca/cryptography/pull/11328).



The original branch is fork-11328-tiran/engine-include