### PR TITLE
Bump ruff from 0.5.4 to 0.5.5

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -105,7 +105,7 @@ readme-renderer==43.0
     # via cryptography (pyproject.toml)
 requests==2.32.3
     # via sphinx
-ruff==0.5.4
+ruff==0.5.5
     # via cryptography (pyproject.toml)
 snowballstemmer==2.2.0
     # via sphinx


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11347](https://togithub.com/pyca/cryptography/pull/11347).



The original branch is upstream/dependabot/pip/ruff-0.5.5