### PR TITLE
Bump alabaster from 0.7.16 to 1.0.0

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -5,7 +5,7 @@
 # and then manually massaged to add version specifiers to packages whose
 # versions vary by Python version
 
-alabaster==0.7.16
+alabaster==1.0.0
     # via sphinx
 argcomplete==3.5.0; python_version >= "3.8"
     # via nox


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11359](https://togithub.com/pyca/cryptography/pull/11359).



The original branch is upstream/dependabot/pip/alabaster-1.0.0