### PR TITLE
Bump sphinxcontrib-applehelp from 1.0.8 to 2.0.0

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -122,7 +122,7 @@ sphinx==7.4.7
     #   sphinxcontrib-spelling
 sphinx-rtd-theme==2.0.0
     # via cryptography (pyproject.toml)
-sphinxcontrib-applehelp==1.0.8
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==1.0.6
     # via sphinx


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11358](https://togithub.com/pyca/cryptography/pull/11358).



The original branch is upstream/dependabot/pip/sphinxcontrib-applehelp-2.0.0