### PR TITLE
Bump sphinxcontrib-devhelp from 1.0.6 to 2.0.0

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -124,7 +124,7 @@ sphinx-rtd-theme==2.0.0
     # via cryptography (pyproject.toml)
 sphinxcontrib-applehelp==1.0.8
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
     # via sphinx


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11356](https://togithub.com/pyca/cryptography/pull/11356).



The original branch is upstream/dependabot/pip/sphinxcontrib-devhelp-2.0.0