### PR TITLE
Bump sphinxcontrib-serializinghtml from 1.1.10 to 2.0.0

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -134,7 +134,7 @@ sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==1.0.8
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sphinxcontrib-spelling==8.0.0
     # via cryptography (pyproject.toml)


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11354](https://togithub.com/pyca/cryptography/pull/11354).



The original branch is upstream/dependabot/pip/sphinxcontrib-serializinghtml-2.0.0