### PR TITLE
Bump asn1 from 0.16.2 to 0.17.0 in /src/rust

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "asn1"
-version = "0.16.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532ceda058281b62096b2add4ab00ab3a453d30dee28b8890f62461a0109ebbd"
+checksum = "147a10032de7d9e6f21c3f1cb1c9c0f94cf30ef67f38310588fe6cfa53e0d3f0"
 dependencies = [
  "asn1_derive",
 ]
 
 [[package]]
 name = "asn1_derive"
-version = "0.16.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6076d38cc17cc22b0f65f31170a2ee1975e6b07f0012893aefd86ce19c987"
+checksum = "3df30ecdcaf8338675a1413460a1b11df89789e1fcc6a10dc52f6e38b6982aa2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -18,7 +18,7 @@ rust-version.workspace = true
 once_cell = "1"
 cfg-if = "1"
 pyo3 = { version = "0.22.2", features = ["abi3"] }
-asn1 = { version = "0.16.2", default-features = false }
+asn1 = { version = "0.17.0", default-features = false }
 cryptography-cffi = { path = "cryptography-cffi" }
 cryptography-keepalive = { path = "cryptography-keepalive" }
 cryptography-key-parsing = { path = "cryptography-key-parsing" }

--- a/src/rust/cryptography-key-parsing/Cargo.toml
+++ b/src/rust/cryptography-key-parsing/Cargo.toml
@@ -7,7 +7,7 @@ publish.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-asn1 = { version = "0.16.2", default-features = false }
+asn1 = { version = "0.17.0", default-features = false }
 cfg-if = "1"
 openssl = "0.10.66"
 openssl-sys = "0.9.103"

--- a/src/rust/cryptography-x509-verification/Cargo.toml
+++ b/src/rust/cryptography-x509-verification/Cargo.toml
@@ -7,7 +7,7 @@ publish.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-asn1 = { version = "0.16.2", default-features = false }
+asn1 = { version = "0.17.0", default-features = false }
 cryptography-x509 = { path = "../cryptography-x509" }
 cryptography-key-parsing = { path = "../cryptography-key-parsing" }
 once_cell = "1"

--- a/src/rust/cryptography-x509/Cargo.toml
+++ b/src/rust/cryptography-x509/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 rust-version = "1.65.0"
 
 [dependencies]
-asn1 = { version = "0.16.2", default-features = false }
+asn1 = { version = "0.17.0", default-features = false }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11378](https://togithub.com/pyca/cryptography/pull/11378).



The original branch is upstream/dependabot/cargo/src/rust/asn1-0.17.0