### PR TITLE
Bump actions/upload-artifact from 4.3.4 to 4.3.5 in /.github/actions/upload-coverage

### DIFF
--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -13,7 +13,7 @@ runs:
         fi
       id: coverage-uuid
       shell: bash
-    - uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+    - uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
       with:
         name: coverage-data-${{ steps.coverage-uuid.outputs.COVERAGE_UUID }}
         path: |


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11390](https://togithub.com/pyca/cryptography/pull/11390).



The original branch is upstream/dependabot/github_actions/dot-github/actions/upload-coverage/actions/upload-artifact-4.3.5