### PR TITLE
Bump coverage from 7.6.0 to 7.6.1

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -25,7 +25,7 @@ click==8.1.7
     # via cryptography (pyproject.toml)
 colorlog==6.8.2
     # via nox
-coverage==7.6.0; python_version >= "3.8"
+coverage==7.6.1; python_version >= "3.8"
     # via
     #   coverage
     #   pytest-cov


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11392](https://togithub.com/pyca/cryptography/pull/11392).



The original branch is upstream/dependabot/pip/coverage-7.6.1