### PR TITLE
Bump argcomplete from 3.4.0 to 3.5.0

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -7,7 +7,7 @@
 
 alabaster==0.7.16
     # via sphinx
-argcomplete==3.4.0; python_version >= "3.8"
+argcomplete==3.5.0; python_version >= "3.8"
     # via nox
 babel==2.15.0
     # via sphinx


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11399](https://togithub.com/pyca/cryptography/pull/11399).



The original branch is upstream/dependabot/pip/argcomplete-3.5.0