### PR TITLE
Bump actions/upload-artifact from 4.3.5 to 4.3.6 in /.github/actions/upload-coverage

### DIFF
--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -13,7 +13,7 @@ runs:
         fi
       id: coverage-uuid
       shell: bash
-    - uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
       with:
         name: coverage-data-${{ steps.coverage-uuid.outputs.COVERAGE_UUID }}
         path: |


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11398](https://togithub.com/pyca/cryptography/pull/11398).



The original branch is upstream/dependabot/github_actions/dot-github/actions/upload-coverage/actions/upload-artifact-4.3.6