### PR TITLE
Run Python tests in CI with debug rust builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           - {VERSION: "3.12", NOXSESSION: "rust,tests", RUST: "1.65.0"}
           - {VERSION: "3.12", NOXSESSION: "rust,tests", RUST: "beta"}
           - {VERSION: "3.12", NOXSESSION: "rust,tests", RUST: "nightly"}
+          - {VERSION: "3.12", NOXSESSION: "tests-rust-debug"}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,6 +46,7 @@ def load_pyproject_toml() -> dict:
 @nox.session(name="tests-ssh")
 @nox.session(name="tests-randomorder")
 @nox.session(name="tests-nocoverage")
+@nox.session(name="tests-rust-debug")
 def tests(session: nox.Session) -> None:
     extras = "test"
     if session.name == "tests-ssh":
@@ -66,7 +67,14 @@ def tests(session: nox.Session) -> None:
         )
 
     install(session, "-e", "./vectors")
-    install(session, f".[{extras}]")
+    if session.name == "tests-rust-debug":
+        install(
+            session,
+            "--config-settings=build-args=--profile=dev",
+            f".[{extras}]",
+        )
+    else:
+        install(session, f".[{extras}]")
 
     session.run("pip", "list")
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11406](https://togithub.com/pyca/cryptography/pull/11406).



The original branch is fork-11406-alex/rust-debug