### PR TITLE
Bump babel from 2.15.0 to 2.16.0

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -9,7 +9,7 @@ alabaster==0.7.16
     # via sphinx
 argcomplete==3.5.0; python_version >= "3.8"
     # via nox
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 build==1.2.1
     # via


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11409](https://togithub.com/pyca/cryptography/pull/11409).



The original branch is upstream/dependabot/pip/babel-2.16.0