### PR TITLE
Allow rsa pkcs#1 decryption of ciphertexts less-than or equal to key-size

### DIFF
--- a/src/rust/src/backend/rsa.rs
+++ b/src/rust/src/backend/rsa.rs
@@ -316,10 +316,10 @@ impl RsaPrivateKey {
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         let key_size_bytes =
             usize::try_from((self.pkey.rsa().unwrap().n().num_bits() + 7) / 8).unwrap();
-        if key_size_bytes != ciphertext.len() {
+        if key_size_bytes <= ciphertext.len() {
             return Err(CryptographyError::from(
                 pyo3::exceptions::PyValueError::new_err(
-                    "Ciphertext length must be equal to key size.",
+                    "Ciphertext length must be less-than or equal to key size.",
                 ),
             ));
         }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11411](https://togithub.com/pyca/cryptography/pull/11411).



The original branch is fork-11411-arlenyan/jsbn