### PR TITLE
Bump syn from 2.0.72 to 2.0.73 in /src/rust

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -325,9 +325,9 @@ checksum = "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "837a7e8026c6ce912ff01cefbe8cafc2f8010ac49682e2a3d9decc3bce1ecaaf"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11416](https://togithub.com/pyca/cryptography/pull/11416).



The original branch is upstream/dependabot/cargo/src/rust/syn-2.0.73