### PR TITLE
Add support for extract_timestamp in MultiFernet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Changelog
 
 * Enforce the :rfc:`5280` requirement that extended key usage extensions must
   not be empty.
+* Added support for timestamp extraction to the
+  :class:`~cryptography.fernet.MultiFernet` class.
 
 .. _v43-0-0:
 

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -213,3 +213,11 @@ class MultiFernet:
             except InvalidToken:
                 pass
         raise InvalidToken
+
+    def extract_timestamp(self, msg: bytes | str) -> int:
+        for f in self._fernets:
+            try:
+                return f.extract_timestamp(msg)
+            except InvalidToken:
+                pass
+        raise InvalidToken


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11427](https://togithub.com/pyca/cryptography/pull/11427).



The original branch is fork-11427-maxmelamed/main