### PR TITLE
Bump cc from 1.1.12 to 1.1.13 in /src/rust

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -42,9 +42,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "cc"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68064e60dbf1f17005c2fde4d07c16d8baa506fd7ffed8ccab702d93617975c7"
+checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
 dependencies = [
  "shlex",
 ]

--- a/src/rust/cryptography-cffi/Cargo.toml
+++ b/src/rust/cryptography-cffi/Cargo.toml
@@ -11,4 +11,4 @@ pyo3 = { version = "0.22.2", features = ["abi3"] }
 openssl-sys = "0.9.103"
 
 [build-dependencies]
-cc = "1.1.12"
+cc = "1.1.13"


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11439](https://togithub.com/pyca/cryptography/pull/11439).



The original branch is upstream/dependabot/cargo/src/rust/cc-1.1.13