### PR TITLE
fixes #11453 -- include localKeyID when serializaing a key with a cert

### DIFF
--- a/src/rust/cryptography-x509/src/pkcs12.rs
+++ b/src/rust/cryptography-x509/src/pkcs12.rs
@@ -11,6 +11,7 @@ pub const SHROUDED_KEY_BAG_OID: asn1::ObjectIdentifier =
     asn1::oid!(1, 2, 840, 113549, 1, 12, 10, 1, 2);
 pub const X509_CERTIFICATE_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 9, 22, 1);
 pub const FRIENDLY_NAME_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 9, 20);
+pub const LOCAL_KEY_ID_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 9, 21);
 
 #[derive(asn1::Asn1Write)]
 pub struct Pfx<'a> {
@@ -46,6 +47,9 @@ pub struct Attribute<'a> {
 pub enum AttributeSet<'a> {
     #[defined_by(FRIENDLY_NAME_OID)]
     FriendlyName(asn1::SetOfWriter<'a, Utf8StoredBMPString<'a>, [Utf8StoredBMPString<'a>; 1]>),
+
+    #[defined_by(LOCAL_KEY_ID_OID)]
+    LocalKeyId(asn1::SetOfWriter<'a, &'a [u8], [&'a [u8]; 1]>),
 }
 
 #[derive(asn1::Asn1DefinedByWrite)]

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -84,16 +84,16 @@ impl Certificate {
         )
     }
 
-    fn fingerprint<'p>(
+    pub(crate) fn fingerprint<'p>(
         &self,
         py: pyo3::Python<'p>,
         algorithm: &pyo3::Bound<'p, pyo3::PyAny>,
-    ) -> CryptographyResult<pyo3::Bound<'p, pyo3::PyAny>> {
+    ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         let serialized = asn1::write_single(&self.raw.borrow_dependent())?;
 
         let mut h = hashes::Hash::new(py, algorithm, None)?;
         h.update_bytes(&serialized)?;
-        Ok(h.finalize(py)?.into_any())
+        h.finalize(py)
     }
 
     fn public_bytes<'p>(


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11454](https://togithub.com/pyca/cryptography/pull/11454).



The original branch is fork-11454-alex/pkcs12-local-key-id