### PR TITLE
webstore.ansi.org is now behind cloudflare

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -205,6 +205,8 @@ linkcheck_ignore = [
     r"https://github.com/.*/blob/.*#L\d+",
     # Kuleuven struggles with the endless forward march of time
     r"https://www.cosic.esat.kuleuven.be",
+    # CMU doesn't know how to send intermediates
+    r"https://wiki.sei.cmu.edu",
 ]
 
 autosectionlabel_prefix_document = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -199,6 +199,7 @@ linkcheck_ignore = [
     r"https://speakerdeck.com",
     r"https://\w+.stackexchange.com",
     r"https://stackoverflow.com",
+    r"https://webstore.ansi.org",
     # GitHub changed how they do page renders so anchor detection
     # no longer works in source view
     r"https://github.com/.*/blob/.*#L\d+",


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11477](https://togithub.com/pyca/cryptography/pull/11477).



The original branch is fork-11477-reaperhulk/ansi-linkcheck