### PR TITLE
Bump idna from 3.7 to 3.8

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -42,7 +42,7 @@ execnet==2.1.1; python_version >= "3.8"
     # via pytest-xdist
 filelock==3.15.4; python_version >= "3.8"
     # via virtualenv
-idna==3.7
+idna==3.8
     # via requests
 imagesize==1.4.1
     # via sphinx


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11483](https://togithub.com/pyca/cryptography/pull/11483).



The original branch is upstream/dependabot/pip/idna-3.8