### PR TITLE
Restrict setuptools version to work around breakages

### DIFF
--- a/.github/requirements/build-requirements.in
+++ b/.github/requirements/build-requirements.in
@@ -1,5 +1,5 @@
 # Must be kept sync with build-system.requires at pyproject.toml
-setuptools>=61.0.0
+setuptools!=74.0.0
 cffi>=1.12; platform_python_implementation != 'PyPy'
 maturin>=1,<2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     "cffi>=1.12; platform_python_implementation != 'PyPy'",
     # Needed because cffi imports distutils, and in Python 3.12, distutils has
     # been removed from the stdlib, but installing setuptools puts it back.
-    "setuptools",
+    "setuptools!=74.0.0",
 ]
 build-backend = "maturin"
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11503](https://togithub.com/pyca/cryptography/pull/11503).



The original branch is fork-11503-alex/setuptools-pin