### PR TITLE
Bump certifi from 2024.7.4 to 2024.8.30

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -15,7 +15,7 @@ build==1.2.1
     # via
     #   check-sdist
     #   cryptography (pyproject.toml)
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11509](https://togithub.com/pyca/cryptography/pull/11509).



The original branch is upstream/dependabot/pip/certifi-2024.8.30