### PR TITLE
Remove duplication of already_finalized_error

### DIFF
--- a/src/rust/src/backend/ciphers.rs
+++ b/src/rust/src/backend/ciphers.rs
@@ -259,8 +259,8 @@ struct PyAEADDecryptionContext {
     aad_bytes_remaining: u64,
 }
 
-fn get_mut_ctx(ctx: Option<&mut CipherContext>) -> pyo3::PyResult<&mut CipherContext> {
-    ctx.ok_or_else(|| exceptions::AlreadyFinalized::new_err("Context was already finalized."))
+fn get_mut_ctx(ctx: Option<&mut CipherContext>) -> CryptographyResult<&mut CipherContext> {
+    ctx.ok_or_else(exceptions::already_finalized_error)
 }
 
 #[pyo3::pymethods]

--- a/src/rust/src/backend/cmac.rs
+++ b/src/rust/src/backend/cmac.rs
@@ -3,7 +3,6 @@
 // for complete details.
 
 use crate::backend::cipher_registry;
-use crate::backend::hashes::already_finalized_error;
 use crate::buf::CffiBuf;
 use crate::error::{CryptographyError, CryptographyResult};
 use crate::{exceptions, types};
@@ -22,14 +21,14 @@ impl Cmac {
         if let Some(ctx) = self.ctx.as_ref() {
             return Ok(ctx);
         };
-        Err(already_finalized_error())
+        Err(exceptions::already_finalized_error())
     }
 
     fn get_mut_ctx(&mut self) -> CryptographyResult<&mut cryptography_openssl::cmac::Cmac> {
         if let Some(ctx) = self.ctx.as_mut() {
             return Ok(ctx);
         }
-        Err(already_finalized_error())
+        Err(exceptions::already_finalized_error())
     }
 }
 

--- a/src/rust/src/backend/hashes.rs
+++ b/src/rust/src/backend/hashes.rs
@@ -17,25 +17,19 @@ pub(crate) struct Hash {
     ctx: Option<openssl::hash::Hasher>,
 }
 
-pub(crate) fn already_finalized_error() -> CryptographyError {
-    CryptographyError::from(exceptions::AlreadyFinalized::new_err(
-        "Context was already finalized.",
-    ))
-}
-
 impl Hash {
     fn get_ctx(&self) -> CryptographyResult<&openssl::hash::Hasher> {
         if let Some(ctx) = self.ctx.as_ref() {
             return Ok(ctx);
         };
-        Err(already_finalized_error())
+        Err(exceptions::already_finalized_error())
     }
 
     fn get_mut_ctx(&mut self) -> CryptographyResult<&mut openssl::hash::Hasher> {
         if let Some(ctx) = self.ctx.as_mut() {
             return Ok(ctx);
         }
-        Err(already_finalized_error())
+        Err(exceptions::already_finalized_error())
     }
 }
 

--- a/src/rust/src/backend/hmac.rs
+++ b/src/rust/src/backend/hmac.rs
@@ -2,7 +2,7 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use crate::backend::hashes::{already_finalized_error, message_digest_from_algorithm};
+use crate::backend::hashes::message_digest_from_algorithm;
 use crate::buf::CffiBuf;
 use crate::error::{CryptographyError, CryptographyResult};
 use crate::exceptions;
@@ -47,14 +47,14 @@ impl Hmac {
         if let Some(ctx) = self.ctx.as_ref() {
             return Ok(ctx);
         };
-        Err(already_finalized_error())
+        Err(exceptions::already_finalized_error())
     }
 
     fn get_mut_ctx(&mut self) -> CryptographyResult<&mut cryptography_openssl::hmac::Hmac> {
         if let Some(ctx) = self.ctx.as_mut() {
             return Ok(ctx);
         }
-        Err(already_finalized_error())
+        Err(exceptions::already_finalized_error())
     }
 }
 

--- a/src/rust/src/backend/poly1305.rs
+++ b/src/rust/src/backend/poly1305.rs
@@ -2,7 +2,6 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use crate::backend::hashes::already_finalized_error;
 use crate::buf::CffiBuf;
 use crate::error::{CryptographyError, CryptographyResult};
 use crate::exceptions;
@@ -136,7 +135,9 @@ impl Poly1305 {
     fn update(&mut self, data: CffiBuf<'_>) -> CryptographyResult<()> {
         self.inner
             .as_mut()
-            .map_or(Err(already_finalized_error()), |b| b.update(data))
+            .map_or(Err(exceptions::already_finalized_error()), |b| {
+                b.update(data)
+            })
     }
 
     fn finalize<'p>(
@@ -146,7 +147,9 @@ impl Poly1305 {
         let res = self
             .inner
             .as_mut()
-            .map_or(Err(already_finalized_error()), |b| b.finalize(py));
+            .map_or(Err(exceptions::already_finalized_error()), |b| {
+                b.finalize(py)
+            });
         self.inner = None;
 
         res

--- a/src/rust/src/exceptions.rs
+++ b/src/rust/src/exceptions.rs
@@ -2,6 +2,8 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use crate::error::CryptographyError;
+
 #[pyo3::pyclass(
     frozen,
     eq,
@@ -36,6 +38,10 @@ pyo3::import_exception_bound!(cryptography.x509, AttributeNotFound);
 pyo3::import_exception_bound!(cryptography.x509, DuplicateExtension);
 pyo3::import_exception_bound!(cryptography.x509, UnsupportedGeneralNameType);
 pyo3::import_exception_bound!(cryptography.x509, InvalidVersion);
+
+pub(crate) fn already_finalized_error() -> CryptographyError {
+    CryptographyError::from(AlreadyFinalized::new_err("Context was already finalized."))
+}
 
 #[pyo3::pymodule]
 pub(crate) mod exceptions {

--- a/src/rust/src/padding.rs
+++ b/src/rust/src/padding.rs
@@ -3,7 +3,7 @@
 // for complete details.
 
 use crate::buf::CffiBuf;
-use crate::error::{CryptographyError, CryptographyResult};
+use crate::error::CryptographyResult;
 use crate::exceptions;
 
 /// Returns the value of the input with the most-significant-bit copied to all
@@ -92,9 +92,7 @@ impl PKCS7PaddingContext {
                 *v += buf.as_bytes().len();
                 Ok(buf.into_pyobj())
             }
-            None => Err(CryptographyError::from(
-                exceptions::AlreadyFinalized::new_err("Context was already finalized."),
-            )),
+            None => Err(exceptions::already_finalized_error()),
         }
     }
 
@@ -108,9 +106,7 @@ impl PKCS7PaddingContext {
                 let pad = vec![pad_size as u8; pad_size];
                 Ok(pyo3::types::PyBytes::new_bound(py, &pad))
             }
-            None => Err(CryptographyError::from(
-                exceptions::AlreadyFinalized::new_err("Context was already finalized."),
-            )),
+            None => Err(exceptions::already_finalized_error()),
         }
     }
 }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11513](https://togithub.com/pyca/cryptography/pull/11513).



The original branch is fork-11513-alex/reduce-duplication