### PR TITLE
Bump actions/upload-artifact from 4.3.6 to 4.4.0 in /.github/actions/upload-coverage

### DIFF
--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -13,7 +13,7 @@ runs:
         fi
       id: coverage-uuid
       shell: bash
-    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:
         name: coverage-data-${{ steps.coverage-uuid.outputs.COVERAGE_UUID }}
         path: |

--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -20,3 +20,4 @@ runs:
           .coverage.*
           *.lcov
         if-no-files-found: ignore
+        include-hidden-files: true


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11519](https://togithub.com/pyca/cryptography/pull/11519).



The original branch is upstream/dependabot/github_actions/dot-github/actions/upload-coverage/actions/upload-artifact-4.4.0