### PR TITLE
port 43.0.1 changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,13 @@ Changelog
   during X.509 verification to allow fields permitted by :rfc:`5280` but
   forbidden by the CA/Browser BRs.
 
+.. _v43-0-1:
+
+43.0.1 - 2024-09-03
+~~~~~~~~~~~~~~~~~~~
+
+* Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.3.2.
+
 .. _v43-0-0:
 
 43.0.0 - 2024-07-20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     "cffi>=1.12; platform_python_implementation != 'PyPy'",
     # Needed because cffi imports distutils, and in Python 3.12, distutils has
     # been removed from the stdlib, but installing setuptools puts it back.
-    "setuptools!=74.0.0,!=74.1.0",
+    "setuptools!=74.0.0,!=74.1.0,!=74.1.1",
 ]
 build-backend = "maturin"
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11534](https://togithub.com/pyca/cryptography/pull/11534).



The original branch is fork-11534-reaperhulk/port-changelog