### PR TITLE
allow sha1 in OAEP

### DIFF
--- a/src/rust/src/backend/rsa.rs
+++ b/src/rust/src/backend/rsa.rs
@@ -70,7 +70,7 @@ fn generate_private_key(public_exponent: u32, key_size: u32) -> CryptographyResu
 }
 
 fn oaep_hash_supported(md: &openssl::hash::MessageDigest) -> bool {
-    (!cryptography_openssl::fips::is_enabled() && md == &openssl::hash::MessageDigest::sha1())
+    md == &openssl::hash::MessageDigest::sha1()
         || md == &openssl::hash::MessageDigest::sha224()
         || md == &openssl::hash::MessageDigest::sha256()
         || md == &openssl::hash::MessageDigest::sha384()


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11536](https://togithub.com/pyca/cryptography/pull/11536).



The original branch is fork-11536-alex/oaep-sha1