### PR TITLE
Bump cc from 1.1.15 to 1.1.16 in /src/rust

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -42,9 +42,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "cc"
-version = "1.1.15"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
 dependencies = [
  "shlex",
 ]

--- a/src/rust/cryptography-cffi/Cargo.toml
+++ b/src/rust/cryptography-cffi/Cargo.toml
@@ -11,4 +11,4 @@ pyo3 = { version = "0.22.2", features = ["abi3"] }
 openssl-sys = "0.9.103"
 
 [build-dependencies]
-cc = "1.1.15"
+cc = "1.1.16"


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11542](https://togithub.com/pyca/cryptography/pull/11542).



The original branch is upstream/dependabot/cargo/src/rust/cc-1.1.16