### PR TITLE
Use uv for building sdists

### DIFF
--- a/.github/requirements/build-requirements.in
+++ b/.github/requirements/build-requirements.in
@@ -3,5 +3,8 @@ setuptools!=74.0.0
 cffi>=1.12; platform_python_implementation != 'PyPy'
 maturin>=1,<2
 
+# Must be kept sync with build-system.requires at vectors/pyproject.toml
+flit_core >=3.2,<4
+
 # WARN: changing the requirements here DOES NOT update the dependencies used for building at the github workflow, as the build process used build-requirements.txt
 # To update build-requirements.txt according to the dependencies here, run pip-compile --allow-unsafe --generate-hashes build-requirements.in

--- a/.github/requirements/build-requirements.txt
+++ b/.github/requirements/build-requirements.txt
@@ -73,6 +73,10 @@ cffi==1.17.1 ; platform_python_implementation != "PyPy" \
     --hash=sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87 \
     --hash=sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b
     # via -r build-requirements.in
+flit-core==3.9.0 \
+    --hash=sha256:72ad266176c4a3fcfab5f2930d76896059851240570ce9a98733b658cb786eba \
+    --hash=sha256:7aada352fb0c7f5538c4fafeddf314d3a6a92ee8e2b1de70482329e42de70301
+    # via -r build-requirements.in
 maturin==1.7.1 \
     --hash=sha256:00f0f8f5051f4c0d0f69bdd0c6297ea87e979f70fb78a377eb4277c932804e2d \
     --hash=sha256:07c8800603e551a45e16fe7ad1742977097ea43c18b28e491df74d4ca15c5857 \

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -33,13 +33,12 @@ jobs:
           ref: ${{ github.event.inputs.version || github.ref }}
           persist-credentials: false
 
-      - run: python -m venv .venv
-      - name: Install Python dependencies
-        run: .venv/bin/pip install -U pip build
+      - run: python -m pip install uv
+
       - name: Make sdist (cryptography)
-        run: .venv/bin/python -m build --sdist
+        run: uv build --build-constraint=$BUILD_REQUIREMENTS_PATH --require-hashes --sdist
       - name: Make sdist and wheel (vectors)
-        run: cd vectors/ && ../.venv/bin/python -m build
+        run: uv build --build-constraint=$BUILD_REQUIREMENTS_PATH --require-hashes vectors/
       - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: "cryptography-sdist"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     "cffi>=1.12; platform_python_implementation != 'PyPy'",
     # Needed because cffi imports distutils, and in Python 3.12, distutils has
     # been removed from the stdlib, but installing setuptools puts it back.
-    "setuptools!=74.0.0,!=74.1.0,!=74.1.1",
+    "setuptools!=74.0.0,!=74.1.0,!=74.1.1,!=74.1.2",
 ]
 build-backend = "maturin"
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pyca/cryptography#11549](https://togithub.com/pyca/cryptography/pull/11549).



The original branch is fork-11549-alex/uv-build-sdist